### PR TITLE
Build for Go 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go_import_path: github.com/codedellemc/rexray
 language: go
 
 go:
-  - 1.7
+  - 1.7.3
 
 before_install:
   - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'


### PR DESCRIPTION
This patch builds REX-Ray for Go 1.7.3.