### PR TITLE
Fix for No Volumes Avai for some commmands

### DIFF
--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -800,6 +800,12 @@ func (c *CLI) lsVolumes(
 	args []string,
 	validStatuses ...string) (*lsVolumesResult, error) {
 
+	// if the volume status matters then send the flag that requests a
+	// volume's attachment information
+	if len(validStatuses) > 0 {
+		c.volumeAttached = true
+	}
+
 	opts := &apitypes.VolumesOpts{Attachments: c.volumeAttached}
 	vols, err := c.r.Storage().Volumes(c.ctx, opts)
 	if err != nil {


### PR DESCRIPTION
This patch updates REX-Ray to request a volume's attachments if a CLI command is executed that depends upon a volume's status to determine its candidacy for said operation. For example, only "available" volumes (those not attached to another host) can be attached to a host. Only volumes that are "attached" can be detached.

This patch handles issue #610 and part of issue #609.