### PR TITLE
Revert "Fix for No Volumes Avai for some commmands"

### DIFF
--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -803,12 +803,6 @@ func (c *CLI) lsVolumes(
 	args []string,
 	validStatuses ...string) (*lsVolumesResult, error) {
 
-	// if the volume status matters then send the flag that requests a
-	// volume's attachment information
-	if len(validStatuses) > 0 {
-		c.volumeAttached = true
-	}
-
 	opts := &apitypes.VolumesOpts{Attachments: c.volumeAttached}
 	vols, err := c.r.Storage().Volumes(c.ctx, opts)
 	if err != nil {


### PR DESCRIPTION
Reverts codedellemc/rexray#613

This patch is being reverted because it breaks some drivers, such as EBS, which return only volumes that are attached to the client when this value is set.

Further discussion of #609 is required.