### PR TITLE
WiP - libStorage 0.3.3-rc2

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -103,6 +103,8 @@ type CLI struct {
 	volumeID                string
 	runAsync                bool
 	volumeAttached          bool
+	volumeAttachedToMe      bool
+	volumeUnattached        bool
 	description             string
 	volumeType              string
 	iops                    int64

--- a/glide-docker.yaml
+++ b/glide-docker.yaml
@@ -10,7 +10,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: v0.3.2 # libstorage-version
+    version: v0.3.3-rc2 # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e437275da2ef474d677f0860d4c353c08536f3af96f24a84a517ae0e2526f6af
-updated: 2016-10-28T18:04:37.530606158-05:00
+hash: 4b2477e13413694c0dfa3ec697e1499befbb067582065261c68d123227ffa2c4
+updated: 2016-11-02T13:46:36.640260776-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 697c16916338166671910eeaccc50f21e3c10726
@@ -73,7 +73,7 @@ imports:
   subpackages:
   - logrus
 - name: github.com/codedellemc/libstorage
-  version: 96e6a3a257dccbbd07b13d8b02e06bd9a4ed2ae9
+  version: 243107c294b259933e1511da911a1d8a17775dbb
   repo: https://github.com/codedellemc/libstorage
   subpackages:
   - api

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: v0.3.2 # libstorage-version
+    version: v0.3.3-rc2 # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig


### PR DESCRIPTION
This patch updates REX-Ray to work with libStorage 0.3.3-rc2 and its new volume attachment query/filter framework.