### PR TITLE
Show correct status after volume mount command

### DIFF
--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -360,9 +360,6 @@ func (c *CLI) initVolumeCmds() {
 					NewFSType:   c.fsType,
 					OverwriteFS: c.overwriteFs,
 				}
-				withAttachments = []*apitypes.VolumeAttachment{
-					&apitypes.VolumeAttachment{InstanceID: result.iid},
-				}
 			)
 
 			for _, v := range result.vols {
@@ -374,7 +371,7 @@ func (c *CLI) initVolumeCmds() {
 					processed = append(processed, &volumeWithPath{v, ""})
 					continue
 				}
-				p, _, err := c.r.Integration().Mount(c.ctx, v.ID, "", opts)
+				p, uv, err := c.r.Integration().Mount(c.ctx, v.ID, "", opts)
 				if err != nil {
 					c.logVolumeLoopError(
 						processed,
@@ -383,8 +380,7 @@ func (c *CLI) initVolumeCmds() {
 						err)
 					continue
 				}
-				nv := &volumeWithPath{v, p}
-				nv.Attachments = withAttachments
+				nv := &volumeWithPath{uv, p}
 				processed = append(processed, nv)
 			}
 			c.mustMarshalOutput(processed, nil)


### PR DESCRIPTION
The displayed mount/attachment status was based on the volume info
retrieved *before* the mount occured. The integration driver is already
returning an updated volume struct, but it was being ignored. If you use
the updated value for output instead, you will see the correct status
displayed.

This mean status will show up as "attached" after a successful mount,
instead of the confusing "available".

Example from current code:
```
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume mount rbd.test
ID        Name  Status     Size  Path
rbd.test  test  available  10    /var/lib/libstorage/volumes/test/data
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume ls
ID        Name  Status    Size
rbd.test  test  attached  10
```

This patch:
```
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume mount rbd.test
ID        Name  Status    Size  Path
rbd.test  test  attached  10    /var/lib/libstorage/volumes/test/data
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume ls
ID        Name  Status    Size
rbd.test  test  attached  10
```