### PR TITLE
Show correct status after volume unmount command

### DIFF
--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -428,7 +428,7 @@ func (c *CLI) initVolumeCmds() {
 					processed = append(processed, v)
 					continue
 				}
-				err := c.r.Integration().Unmount(c.ctx, v.ID, "", opts)
+				nv, err := c.r.Integration().Unmount(c.ctx, v.ID, "", opts)
 				if err != nil {
 					c.logVolumeLoopError(
 						processed,
@@ -437,8 +437,7 @@ func (c *CLI) initVolumeCmds() {
 						err)
 					continue
 				}
-				v.Attachments = nil
-				processed = append(processed, v)
+				processed = append(processed, nv)
 			}
 			c.mustMarshalOutput(processed, nil)
 		},

--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -295,7 +295,7 @@ func (m *mod) buildMux() *http.ServeMux {
 
 		m.ctx.WithField("pluginResponse", pr).Debug("/VolumeDriver.Unmount")
 
-		err := m.lsc.Integration().Unmount(
+		_, err := m.lsc.Integration().Unmount(
 			m.ctx, "", pr.Name, apiutils.NewStore())
 		if err != nil {
 			http.Error(w, fmt.Sprintf("{\"Error\":\"%s\"}", err.Error()), 500)


### PR DESCRIPTION
Use a returned volume object returned by the integration unmount
operation for output instead of volume object obtained at the beginning
of the unmount operation. The updated object has current/correct
attachment info, and therefore will display whether the volume is
actually availabe or still attached to another host.

Before this patch, the status would always display as "attached", which
is definitely not true when the unmount is successful.

Example from current code:
```
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume unmount rbd.test
ID        Name  Status    Size
rbd.test  test  attached  10
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume ls
ID        Name  Status     Size
rbd.test  test  available  10
```

Example with this patch:
```
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume unmount rbd.test
ID        Name  Status     Size
rbd.test  test  available  10
[root@ceph-admin ~]# ~vagrant/rexray -l warn volume ls
ID        Name  Status     Size
rbd.test  test  available  10
```

I split this patch up from #627 because it is more intrusive -- it requires a corresponding change in Libstorage, and that change has a Type change, so I don't expect it to be taken yet. But I at least wanted to show/open this to see what I was thinking.