### PR TITLE
Always request device mapping for vol ls commands

### DIFF
--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -812,12 +812,14 @@ func (c *CLI) defaultAttachments() apitypes.VolumeAttachmentsTypes {
 		return apitypes.VolAttReqOnlyUnattachedVols
 	}
 	if c.volumeAttachedToMe {
-		return apitypes.VolAttReqOnlyVolsAttachedToInstance
+		return apitypes.VolAttReqWithDevMapOnlyVolsAttachedToInstance
 	}
 	if c.volumeAttached {
-		return apitypes.VolAttReqOnlyAttachedVols
+		return apitypes.VolAttReqOnlyAttachedVols |
+			apitypes.VolumeAttachmentsDevices
 	}
-	return apitypes.VolAttReq
+	return apitypes.VolAttReq |
+		apitypes.VolumeAttachmentsDevices
 }
 
 func (c *CLI) lsVolumes(


### PR DESCRIPTION
@cduchesne I think a change like this is what you'd be looking for in #629.

@akutz will have to weigh in on whether it is appropriate to do so. A requirement for getting the Device map info is the client has to send both its Instance ID and its LocalDevice headers. A lot of the changes that have been happing in libStorage 0.3.3 are to account for the fact that drivers should not always expect those to be present. They should only be present when they are required (like for doing a device mapping).

I'm not sure right now if rexray, as a client, is always sending those are not.

The change for `c.volumeAttachedToMe` is probably a good one. This correlates to `rexray volume ls --attachedToMe`.

But when getting all attached vols `--attached`, or *all vols*, I'm not sure if rexray is sending those headers or not. There also aren't convenience fields created with the masks we needed (why I'm `or`'ing two masks) which is a sign to me that maybe that combination is not intended.

But, I always like to throw something out to see what is possible, for discussions. :)