### PR TITLE
CLI Attachment Flags

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -104,8 +104,8 @@ type CLI struct {
 	volumeID                string
 	runAsync                bool
 	volumeAttached          bool
-	volumeAttachedToMe      bool
-	volumeUnattached        bool
+	volumeAvailable         bool
+	volumePath              bool
 	description             string
 	volumeType              string
 	iops                    int64


### PR DESCRIPTION
This patch is in response to, and replaces, PR #630. This patch defines the CLI flags for the `volume ls` command:

* `--path`
* `--attached`
* `--available`

If the `--path` flag is provided, ex. `rexray volume ls --path`, then the volume listing acts as if it were the now removed `volume path` command. 

The `--path` flag supersedes the other two aforementioned flags which themselves are mutually exclusive with the `--attached` flag taking precedence over the `--available` flag. 

If the `--attached` flag is provided then only volumes attached to the current instance are returned. If the `--available` flag is specified then only volumes not attached to any instance are returned.