### PR TITLE
Allow RPM upgrade in install script

### DIFF
--- a/install
+++ b/install
@@ -111,7 +111,7 @@ install() {
         curl $INSECURE -o $FILE_NAME -sSL $URL
         if [ "$?" -ne "0" ]; then exit $?; fi
 
-        sudo rpm -ih --quiet $FILE_NAME > /dev/null
+        sudo rpm -U --quiet $FILE_NAME > /dev/null
         if [ "$?" -ne "0" ]; then ec=$?; rm -f $FILE_NAME; exit $ec; fi
 
         rm -f $FILE_NAME


### PR DESCRIPTION
I hit an error when trying to use the 'staged' rexray version via https://github.com/codedellemc/vagrant/blob/master/rexray/Vagrantfile.  Digging deeper, I don't know how anyone could have used the `install` script to upgrade rexray. Is this intended behavior?


The install script was using `rpm -ih` syntax, which only allows for a
package install. Trying to upgrade the package would result in error
about how /usr/bin/rexray from the new package conflicts with the old
(existing) package.

Instead, use `rpm -U`. We also remove the `-h` option, which prints out
hash marks during unpack, because we are using the `--quiet` option,
which makes `-h` moot.