### PR TITLE
Add bash script for k8s flex driver

### DIFF
--- a/cli/k8sflex/flexrex
+++ b/cli/k8sflex/flexrex
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+# Copyright 2016 Dell EMC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Notes:
+#  - Please install "jq" package before using this driver.
+#  - Please install and configure REX-Ray before using this driver
+usage() {
+	err "Invalid usage. Usage: "
+	err "\t$0 init"
+	err "\t$0 attach <json params>"
+	err "\t$0 detach <mount device>"
+	err "\t$0 mount <mount dir> <mount device> <json params>"
+	err "\t$0 unmount <mount dir>"
+	exit 1
+}
+
+err() {
+	echo -ne $* 1>&2
+}
+
+log() {
+	echo -ne $* >&1
+}
+
+ismounted() {
+	MOUNT=`findmnt -n ${MNTPATH} 2>/dev/null | cut -d' ' -f1`
+	if [ "${MOUNT}" == "${MNTPATH}" ]; then
+		echo "1"
+	else
+		echo "0"
+	fi
+}
+
+attach() {
+	VOLUMEID=$(echo $1 | jq -r '.volumeID')
+	if [ -z $VOLUMEID ]; then
+		err "{\"status\": \"Failure\", \"message\": \"Unable to extract volumeID\"}"
+		exit 1
+	fi
+
+	OUTPUT=$(rexray volume attach ${VOLUMEID} --format json 2>/dev/null)
+
+	if [ $? -ne 0 ]; then
+		err "{\"status\": \"Failure\", \"message\": \"REX-Ray returned error during attach\"}"
+		exit 1
+	fi
+
+	# Make second call to get device info
+	OUTPUT=$(rexray volume ls ${VOLUMEID} --path --format json 2>/dev/null)
+	DEV=$(echo ${OUTPUT} | jq -r '.[0].attachments[0].deviceName')
+	if [ -z $DEV ]; then
+		err "{\"status\": \"Failure\", \"message\": \"REX-Ray did not return attached device name\"}"
+		exit 1
+	fi
+	if [ ! -b "${DEV}" ]; then
+		err "{\"status\": \"Failure\", \"message\": \"Volume ${VOLUMEID} not present at ${DEV}\"}"
+		exit 1
+	fi
+	log "{\"status\": \"Success\", \"device\":\"${DEV}\"}"
+	exit 0
+}
+
+detach() {
+	DEV=$1
+	if [ ! -b "${DEV}" ]; then
+		err "{\"status\": \"Failure\", \"message\": \"Device ${DEV} does not exist\"}"
+		exit 1
+	fi
+
+	VOLUMES=$(rexray volume ls --path --format json)
+	VOLUMEID=$(echo ${VOLUMES} | jq -r '[.[] | {id: .id, device:.attachments[0].deviceName}] | .[] | select(.device == '\"${DEV}\"') | .id')
+
+	if [ -z $VOLUMEID ]; then
+		err "{\"status\": \"Failure\", \"message\": \"Could not find source volume for device ${DEV}\"}"
+		exit 1
+	fi
+
+	rexray volume detach ${VOLUMEID} >/dev/null 2>&1
+	if [ $? -ne 0 ]; then
+		err "{\"status\": \"Failure\", \"message\": \"REX-Ray returned error during detach\"}"
+		exit 1
+	fi
+
+	log "{\"status\": \"Success\"}"
+	exit 0
+}
+
+domount() {
+	MNTPATH=$1
+	DEV=$2
+	FSTYPE=$(echo $3|jq -r '.["kubernetes.io/fsType"]')
+
+	if [ ! -b "${DEV}" ]; then
+		err "{\"status\": \"Failure\", \"message\": \"${DEV} does not exist\"}"
+		exit 1
+	fi
+
+	if [ $(ismounted) -eq 1 ] ; then
+		log "{\"status\": \"Success\"}"
+		exit 0
+	fi
+
+	VOLFSTYPE=`blkid -o udev ${DEV} 2>/dev/null|grep "ID_FS_TYPE"|cut -d"=" -f2`
+	if [ "${VOLFSTYPE}" == "" ]; then
+		CMD="mkfs -t ${FSTYPE}"
+		if [ $FSTYPE == "ext4" ]; then
+			CMD="${CMD} -F"
+		elif [ $FSTYPE == "xfs" ]; then
+			CMD="${CMD} -f"
+		fi
+		$(${CMD} ${DEV} >/dev/null 2>&1)
+		if [ $? -ne 0 ]; then
+			err "{ \"status\": \"Failure\", \"message\": \"Failed to create fs ${FSTYPE} on device ${DEV}\"}"
+			exit 1
+		fi
+	fi
+
+	mkdir -p ${MNTPATH} &> /dev/null
+
+	mount ${DEV} ${MNTPATH} &> /dev/null
+	if [ $? -ne 0 ]; then
+		err "{ \"status\": \"Failure\", \"message\": \"Failed to mount device ${DEV} at ${MNTPATH}\"}"
+		exit 1
+	fi
+	log "{\"status\": \"Success\"}"
+	exit 0
+}
+
+unmount() {
+	MNTPATH=$1
+	if [ $(ismounted) -eq 0 ] ; then
+		log "{\"status\": \"Success\"}"
+		exit 0
+	fi
+
+	umount ${MNTPATH} &> /dev/null
+	if [ $? -ne 0 ]; then
+		err "{ \"status\": \"Failed\", \"message\": \"Failed to unmount volume at ${MNTPATH}\"}"
+		exit 1
+	fi
+	rmdir ${MNTPATH} &> /dev/null
+
+	log "{\"status\": \"Success\"}"
+	exit 0
+}
+
+op=$1
+
+if [ "$op" = "init" ]; then
+	log "{\"status\": \"Success\"}"
+	exit 0
+fi
+
+if [ $# -lt 2 ]; then
+	usage
+fi
+
+shift
+
+case "$op" in
+	attach)
+		attach $*
+		;;
+	detach)
+		detach $*
+		;;
+	mount)
+		domount $*
+		;;
+	unmount)
+		unmount $*
+		;;
+	*)
+		usage
+esac
+
+exit 1


### PR DESCRIPTION
This introduces a 'flexrex' script that can be installed and used as a Kubernetes
Flex Volume driver. See: https://github.com/kubernetes/kubernetes/tree/master/examples/volumes/flexvolume

This script makes calls to rexray for attach/detach, but does not use rexray for
mount/umount because the behavior that k8s needs is different from what
is built into the Docker integration driver.

Examples:

```
rexray volume create test --size 5
flexrex attach '{"volumeID":"test"}'
flexrex mount '/mnt/test' '/dev/sdb' '{"kubernetes.io/fsType":"ext4"}'
flexrex unmount /mnt/test
flexrex detach '/dev/sdb'
```

I made sure that both xfs and ext4 fs types work. The lvm example given for the flex driver does not work on unpartitioned block devices.

Testing has not been done with k8s proper at this point, only with the `flexrex` script directly, as described in the examples above.  cc/ @cduchesne 

This script only works with rexray starting with v0.6.1, as it requires the `volume ls --path` functionality`.  Not entirely sure where the script should live at this point, so I just proposed a place. Purpose of PR is to get to @cduchesne for testing.