### PR TITLE
Auto-Detect Running Service

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -136,7 +136,7 @@ func TestPrefixAndDirs(t *testing.T) {
 func TestStdOutAndLogFile(t *testing.T) {
 	newPrefixDir("TestStdOutAndLogFile", t)
 
-	if _, err := StdOutAndLogFile("BadFile/"); err == nil {
+	if _, err := StdOutAndLogFile("BadFile/ (*$"); err == nil {
 		t.Fatal("error expected in created BadFile")
 	}
 


### PR DESCRIPTION
This patch handles issue #589 so that a REX-Ray client will automatically detect a running libStorage service if it was started by REX-Ray, even via embedded mode. This means that even if the REX-Ray configuration file relies on auto-service mode where a host is not explicitly defined, if a libStorage server is started in this manner, subsequent REX-Ray executions will not start additional servers, instead attaching to the existing service.

- [x] Successful test result
  - [x] @cduchesne 
  - [x] @akutz 