### PR TITLE
Fix for Non-Graceful Exit w SystemD

### DIFF
--- a/cli/cli/service.go
+++ b/cli/cli/service.go
@@ -196,7 +196,14 @@ func (c *CLI) startDaemon() {
 		stop <- s
 		close(stop)
 
-		os.Remove(serverSockFile)
+		if err := os.Remove(serverSockFile); err == nil {
+			ctx.WithField(
+				"sockFile", serverSockFile).Info("removed server sock file")
+		}
+		if err := os.Remove(util.PidFilePath()); err == nil {
+			ctx.WithField(
+				"pidFile", util.PidFilePath()).Info("removed pid file")
+		}
 
 		// wait until the daemon stops
 		for range errs {

--- a/core/core.go
+++ b/core/core.go
@@ -107,13 +107,13 @@ func TrapSignals(ctx apitypes.Context) {
 
 // IsExitSignal returns a flag indicating whether a signal is SIGKILL, SIGHUP,
 // SIGINT, SIGTERM, or SIGQUIT. The second return value is whether it is a
-// graceful exit. This flag is true for SIGHUP, SIGINT, and SIGQUIT.
+// graceful exit. This flag is true for SIGTERM, SIGHUP, SIGINT, and SIGQUIT.
 func IsExitSignal(s os.Signal) (bool, bool) {
 	switch s {
-	case syscall.SIGKILL,
-		syscall.SIGTERM:
+	case syscall.SIGKILL:
 		return true, false
-	case syscall.SIGHUP,
+	case syscall.SIGTERM,
+		syscall.SIGHUP,
 		syscall.SIGINT,
 		syscall.SIGQUIT:
 		return true, true


### PR DESCRIPTION
This patch updates the way REX-Ray traps signals and fixes the logic so that `SIGTERM` causes a graceful exist in accordance with the GNU and Linux standard practices.