### PR TITLE
Support for Creating Encrypted Volumes

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -127,6 +127,7 @@ type CLI struct {
 	moduleInstanceAddress   string
 	moduleInstanceStart     bool
 	moduleConfig            []string
+	encrypted               bool
 }
 
 const (

--- a/cli/cli/cli_formatter.go
+++ b/cli/cli/cli_formatter.go
@@ -74,12 +74,34 @@ func (c *CLI) fmtOutput(w io.Writer, templateName string, o interface{}) error {
 		case *apitypes.Volume:
 			return c.fmtOutput(w, templName, []*apitypes.Volume{to})
 		case []*apitypes.Volume:
+			isEnc := false
+			for _, v := range to {
+				if v.Encrypted {
+					isEnc = true
+					break
+				}
+			}
 			if templName == "" {
-				templName = templateNamePrintVolumeFields
+				if isEnc {
+					templName = templateNamePrintEncVolumeFields
+				} else {
+					templName = templateNamePrintVolumeFields
+				}
 			}
 		case []*volumeWithPath:
+			isEnc := false
+			for _, v := range to {
+				if v.Encrypted {
+					isEnc = true
+					break
+				}
+			}
 			if templName == "" {
-				templName = templateNamePrintVolumeWithPathFields
+				if isEnc {
+					templName = templateNamePrintEncVolumeWithPathFields
+				} else {
+					templName = templateNamePrintVolumeWithPathFields
+				}
 			}
 		case *apitypes.Snapshot:
 			return c.fmtOutput(w, templName, []*apitypes.Snapshot{to})
@@ -220,18 +242,20 @@ func (c *CLI) mustMarshalOutput3WithTemplateName(
 }
 
 const (
-	templateNamePrintCustom               = "printCustom"
-	templateNamePrintObject               = "printObject"
-	templateNamePrintStringSlice          = "printStringSlice"
-	templateNamePrintJSON                 = "printJSON"
-	templateNamePrintPrettyJSON           = "printPrettyJSON"
-	templateNamePrintVolumeFields         = "printVolumeFields"
-	templateNamePrintVolumeID             = "printVolumeID"
-	templateNamePrintVolumeWithPathFields = "printVolumeWithPathFields"
-	templateNamePrintSnapshotFields       = "printSnapshotFields"
-	templateNamePrintInstanceFields       = "printInstanceFields"
-	templateNamePrintServiceFields        = "printServiceFields"
-	templateNamePrintMountFields          = "printMountFields"
+	templateNamePrintCustom                  = "printCustom"
+	templateNamePrintObject                  = "printObject"
+	templateNamePrintStringSlice             = "printStringSlice"
+	templateNamePrintJSON                    = "printJSON"
+	templateNamePrintPrettyJSON              = "printPrettyJSON"
+	templateNamePrintVolumeFields            = "printVolumeFields"
+	templateNamePrintVolumeID                = "printVolumeID"
+	templateNamePrintVolumeWithPathFields    = "printVolumeWithPathFields"
+	templateNamePrintEncVolumeFields         = "printEncVolumeFields"
+	templateNamePrintEncVolumeWithPathFields = "printEncVolumeWithPathFields"
+	templateNamePrintSnapshotFields          = "printSnapshotFields"
+	templateNamePrintInstanceFields          = "printInstanceFields"
+	templateNamePrintServiceFields           = "printServiceFields"
+	templateNamePrintMountFields             = "printMountFields"
 )
 
 type templateMetadata struct {
@@ -272,6 +296,27 @@ var defaultTemplates = map[string]*templateMetadata{
 			"Name",
 			"Status={{.Volume.AttachmentState | printAttState}}",
 			"Size",
+			"Path",
+		},
+		sortBy: "Name",
+	},
+	templateNamePrintEncVolumeFields: &templateMetadata{
+		fields: []string{
+			"ID",
+			"Name",
+			"Status={{.AttachmentState | printAttState}}",
+			"Size",
+			"Encrypted",
+		},
+		sortBy: "Name",
+	},
+	templateNamePrintEncVolumeWithPathFields: &templateMetadata{
+		fields: []string{
+			"ID",
+			"Name",
+			"Status={{.Volume.AttachmentState | printAttState}}",
+			"Size",
+			"Encrypted",
 			"Path",
 		},
 		sortBy: "Name",

--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -102,6 +102,7 @@ func (c *CLI) initVolumeCmds() {
 					Size:             &c.size,
 					Type:             &c.volumeType,
 					IOPS:             &c.iops,
+					Encrypted:        &c.encrypted,
 					Opts:             store(),
 				}
 			)
@@ -142,6 +143,7 @@ func (c *CLI) initVolumeCmds() {
 						Type:             c.volumeType,
 						IOPS:             c.iops,
 						AvailabilityZone: c.availabilityZone,
+						Encrypted:        c.encrypted,
 					}
 					if c.attach || c.amount {
 						dv.Attachments = withAttachments
@@ -965,6 +967,10 @@ func (c *CLI) initVolumeFlags() {
 	c.volumeCreateCmd.Flags().BoolVar(&c.force, "force", false, "")
 	c.volumeCreateCmd.Flags().BoolVar(&c.overwriteFs, "overwriteFS", false, "")
 	c.volumeCreateCmd.Flags().StringVar(&c.fsType, "fsType", "", "")
+	c.volumeCreateCmd.Flags().BoolVar(&c.encrypted, "encrypted", false,
+		"A flag that requests the storage platform create an encrypted "+
+			"volume. Specifying true doesn't guarantee encryption; it's up "+
+			"the storage driver and platform to implement this feature.")
 
 	c.addQuietFlag(c.volumeCmd.PersistentFlags())
 	c.addOutputFormatFlag(c.volumeCmd.PersistentFlags())


### PR DESCRIPTION
This patch updates the `volume create` command to support the new flag `--encrypted`. When specified, this flag sends an option to the libStorage volume creation API that requests the creation of a new storage volume using encryption. This feature does not guarantee back-end encryption -- it's up to the libStorage storage driver and underlying storage platform to support encryption.