### PR TITLE
Custom Encryption Key for Volume Creation

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -128,6 +128,7 @@ type CLI struct {
 	moduleInstanceStart     bool
 	moduleConfig            []string
 	encrypted               bool
+	encryptionKey           string
 }
 
 const (

--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -107,6 +107,10 @@ func (c *CLI) initVolumeCmds() {
 				}
 			)
 
+			if c.encryptionKey != "" {
+				opts.EncryptionKey = &c.encryptionKey
+			}
+
 			if c.amount {
 				processedPVols = []*volumeWithPath{}
 			} else {
@@ -971,6 +975,8 @@ func (c *CLI) initVolumeFlags() {
 		"A flag that requests the storage platform create an encrypted "+
 			"volume. Specifying true doesn't guarantee encryption; it's up "+
 			"the storage driver and platform to implement this feature.")
+	c.volumeCreateCmd.Flags().StringVar(&c.encryptionKey, "encryptionKey", "",
+		"The key used to encrypt the volume.")
 
 	c.addQuietFlag(c.volumeCmd.PersistentFlags())
 	c.addOutputFormatFlag(c.volumeCmd.PersistentFlags())


### PR DESCRIPTION
This patch updates the CLI to accept a custom encryption key when creating an encrypted volume.