### PR TITLE
Fix Volume Status for Detach Op

### DIFF
--- a/cli/cli/cmds_volume.go
+++ b/cli/cli/cmds_volume.go
@@ -151,6 +151,7 @@ func (c *CLI) initVolumeCmds() {
 					}
 					if c.attach || c.amount {
 						dv.Attachments = withAttachments
+						dv.AttachmentState = apitypes.VolumeAttached
 					}
 					if c.amount {
 						processedPVols = append(
@@ -367,6 +368,7 @@ func (c *CLI) initVolumeCmds() {
 				}
 				if c.dryRun {
 					v.Attachments = nil
+					v.AttachmentState = apitypes.VolumeAvailable
 					processed = append(processed, v)
 					continue
 				}
@@ -380,6 +382,7 @@ func (c *CLI) initVolumeCmds() {
 					continue
 				}
 				v.Attachments = nil
+				v.AttachmentState = apitypes.VolumeAvailable
 				processed = append(processed, v)
 			}
 			c.mustMarshalOutput(processed, nil)
@@ -477,6 +480,7 @@ func (c *CLI) initVolumeCmds() {
 				}
 				if c.dryRun {
 					v.Attachments = nil
+					v.AttachmentState = apitypes.VolumeAvailable
 					processed = append(processed, v)
 					continue
 				}


### PR DESCRIPTION
This patch fixes the issue where a volume's status is not accurately reflected upon being detached as well as a few other operations re: the volume status.