### PR TITLE
Idempotent Commands

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -129,6 +129,7 @@ type CLI struct {
 	moduleConfig            []string
 	encrypted               bool
 	encryptionKey           string
+	idempotent              bool
 }
 
 const (
@@ -304,6 +305,11 @@ func (c *CLI) addDryRunFlag(fs *pflag.FlagSet) {
 func (c *CLI) addContinueOnErrorFlag(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.continueOnError, "continueOnError", false,
 		"Continue processing a collection upon error")
+}
+
+func (c *CLI) addIdempotentFlag(fs *pflag.FlagSet) {
+	fs.BoolVarP(&c.idempotent, "idempotent", "i", false,
+		"Make this command idempotent.")
 }
 
 func (c *CLI) updateLogLevel() {


### PR DESCRIPTION
This patch adds the flag "-i|--idempotent" to the commands `volume attach`, `volume detach`, `volume mount`, and `volume unmount`. Using the new flag means that the command should always emit the same value for a volume even after an operation has completed. For example, if `volume attach` is used to attach a volume named "logs", without the idempotent flag a subsequent `volume attach` operation on the "logs" volume would result in an error indicating that no volumes are available. This is because the above operations normally only act on volumes that are in a state valid for the eponymous operation. Because making these commands idempotent adds overhead, the option is now present but is something that has to be explicitly activated.