### PR TITLE
Driver Builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ ifeq (undefined,$(origin BUILD_TAGS))
 BUILD_TAGS := gofig pflag libstorage_integration_driver_docker
 endif
 
+ifneq (,$(DRIVERS))
+BUILD_TAGS += libstorage_storage_driver libstorage_storage_executor
+BUILD_TAGS += $(foreach d,$(DRIVERS),libstorage_storage_driver_$(d) libstorage_storage_executor_$(d))
+endif
+
 all:
 # if docker is running, then let's use docker to build it
 ifneq (,$(shell if docker version &> /dev/null; then echo -; fi))


### PR DESCRIPTION
This patch updates the REX-Ray Makefile to make it incredibly simple to build REX-Ray with specific drivers only. For example, the following command builds REX-Ray with support for only the ScaleIO driver:

```sh
$ DRIVERS=scaleio make
```

It's also possible to build with support for more than one driver, such as this command which includes both the EBS and EFS drivers:

```sh
$ DRIVERS='ebs efs' make
```

This new build feature works with both Docker builds and standard Makefile builds. 

This update can drastically reduce the size of the REX-Ray binary, removing support for platforms that may be unnecessary to specific deployments.