### PR TITLE
Bugfix for Bintray Distrib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1039,6 +1039,7 @@ BINTRAY_STABLE := bintray-stable.json
 $(BINTRAY_UNSTABLE) $(BINTRAY_STAGED) $(BINTRAY_STABLE): $(BINTRAY_JSON)
 	sed -e 's/$${SUBJ}/$(BINTRAY_SUBJ)/g' \
 		-e 's/$${PROG}/$(PROG)/g' \
+		-e 's/$${PROG_ROOT}/$(PROG_ROOT)/g' \
 		-e 's/$${REPO}/$(subst bintray-,,$(subst .json,,$@))/g' \
 		-e 's/$${SEMVER}/$(V_SEMVER)/g' \
 		-e 's|$${DSCRIP}|$(V_SEMVER).Branch.$(V_BRANCH).Sha.$(V_SHA_LONG)|g' \

--- a/bintray.json
+++ b/bintray.json
@@ -1,7 +1,7 @@
 {
    "package": {
         "name":     "${REPO}",
-        "repo":     "${PROG}",
+        "repo":     "${PROG_ROOT}",
         "subject":  "${SUBJ}"
     },
     "version": {


### PR DESCRIPTION
This patch updates the Bintray logic so that the new types of REX-Ray builds are properly pushed to Bintray upon distribution.