### PR TITLE
Updated libStorage to 0.4.0-rc2

### DIFF
--- a/glide-docker.yaml
+++ b/glide-docker.yaml
@@ -10,7 +10,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: v0.3.6 # libstorage-version
+    version: v0.4.0-rc2 # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e137fbb0517c72219a1c737caf65647bdc02a49ee0708b79d001fcf4c16de9df
-updated: 2016-12-13T10:18:38.579745727-06:00
+hash: 282c3c409e362116dddbbe8243ebc2a61dfb7f8fedea4d90f7a5da18bb6eb740
+updated: 2016-12-16T17:18:40.889553317-06:00
 imports:
 - name: github.com/akutz/gofig
   version: 862741cad5edced279c57d1981e8e3e9fa54e8d5
@@ -77,7 +77,7 @@ imports:
   subpackages:
   - logrus
 - name: github.com/codedellemc/libstorage
-  version: 3654489852a36502979483328eeb5b600e6e4450
+  version: 3245c8e7774b227995e60d39e2de5656ea6b9ca1
   repo: https://github.com/codedellemc/libstorage
   subpackages:
   - api
@@ -106,21 +106,33 @@ imports:
   - drivers/os/darwin
   - drivers/os/linux
   - drivers/storage/ebs
+  - drivers/storage/ebs/executor
   - drivers/storage/ebs/storage
   - drivers/storage/ebs/utils
   - drivers/storage/efs
+  - drivers/storage/efs/executor
   - drivers/storage/efs/storage
+  - drivers/storage/efs/utils
   - drivers/storage/isilon
+  - drivers/storage/isilon/executor
   - drivers/storage/isilon/storage
   - drivers/storage/libstorage
+  - drivers/storage/rbd
+  - drivers/storage/rbd/executor
+  - drivers/storage/rbd/storage
+  - drivers/storage/rbd/utils
   - drivers/storage/scaleio
+  - drivers/storage/scaleio/executor
   - drivers/storage/scaleio/storage
   - drivers/storage/vbox
+  - drivers/storage/vbox/executor
   - drivers/storage/vbox/storage
   - drivers/storage/vfs
   - drivers/storage/vfs/client
+  - drivers/storage/vfs/executor
   - drivers/storage/vfs/storage
   - imports/config
+  - imports/executors
   - imports/local
   - imports/remote
   - imports/routers

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: v0.3.6 # libstorage-version
+    version: v0.4.0-rc2 # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig


### PR DESCRIPTION
This patch updates the libStorage dependency to 0.4.0-rc2.