### PR TITLE
Makefile Bug & Symlink Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,8 @@ ifeq (undefined,$(origin BUILD_TAGS))
 BUILD_TAGS := gofig pflag libstorage_integration_driver_docker
 endif
 
-SCRIPTS_GENERATED_SRC := ./scripts/scripts_generated.go
-ifneq (,$(wildcard $(SCRIPTS_GENERATED_SRC)))
 ifeq (,$(findstring scripts_generated,$(BUILD_TAGS)))
 BUILD_TAGS += scripts_generated
-endif
 endif
 
 ifneq (,$(REXRAY_BUILD_TYPE))
@@ -877,6 +874,7 @@ ifeq (true,$(EMBED_SCRIPTS_FLEXREX))
 SCRIPTS += ./scripts/scripts/flexrex
 endif
 
+SCRIPTS_GENERATED_SRC := ./scripts/scripts_generated.go
 SCRIPTS_A := $(GOPATH)/pkg/$(GOOS)_$(GOARCH)/$(ROOT_IMPORT_PATH)/scripts.a
 
 IGNORE_TEST_SCRIPT_PATT := test(?:\.sh)?$

--- a/cli/cli/cmds_51_flexrex.go
+++ b/cli/cli/cmds_51_flexrex.go
@@ -33,6 +33,9 @@ func (c *CLI) initFlexRexCmds() {
 		Use:   "install",
 		Short: "Install the FlexVol REX-Ray plug-in",
 		Run: func(cmd *cobra.Command, args []string) {
+			if c.force {
+				os.RemoveAll(c.scriptPath)
+			}
 			fp := util.ScriptFilePath("flexrex")
 			if !gotil.FileExists(fp) {
 				if _, err := c.installScripts("flexrex"); err != nil {
@@ -43,15 +46,12 @@ func (c *CLI) initFlexRexCmds() {
 			if err != nil {
 				c.ctx.Fatal(err)
 			}
-			if err := os.Symlink(fp, c.scriptPath); err != nil {
-				c.ctx.Fatal(err)
-			}
 			c.mustMarshalOutput(&scriptInfo{
 				Name:      "flexrex",
 				Path:      c.scriptPath,
 				Installed: true,
 				Modified:  false,
-			}, nil)
+			}, os.Symlink(fp, c.scriptPath))
 		},
 	}
 	c.flexRexCmd.AddCommand(c.flexRexInstallCmd)
@@ -74,6 +74,12 @@ const (
 )
 
 func (c *CLI) initFlexRexFlags() {
+	c.flexRexInstallCmd.Flags().BoolVar(
+		&c.force,
+		"force",
+		false,
+		"A flag indicating whether to install the script even if it already "+
+			"exists at the specified path")
 	c.flexRexInstallCmd.Flags().StringVar(
 		&c.scriptPath,
 		"path",


### PR DESCRIPTION
This patch fixes a bug in the Makefile that prevents scripts from being
compiled into the rexray-client binary. Additionally, this patch adds
the --force flag to the "rexray flexrex install" command to enable
creating a symlink to a location that already exists.