### PR TITLE
update cli volume attach command to check for force flag

### DIFF
--- a/cli/cli/cmds_10_volume.go
+++ b/cli/cli/cmds_10_volume.go
@@ -291,6 +291,12 @@ func (c *CLI) initVolumeCmds() {
 					apitypes.VolAttReqOnlyVolsAttachedToInstanceOrUnattachedVols
 			}
 
+			if c.force {
+				//Get all volumes including those that are unavailable
+				lsVolAttType =
+					apitypes.VolAttReq
+			}
+
 			result, err := c.lsVolumes(args, lsVolAttType)
 			if err != nil {
 				log.Fatal(err)


### PR DESCRIPTION
Update the CLI's `volume attach` command to respect the `--force` flag.