### PR TITLE
removing unneccessary removal of directory from flexrex unmount workflow

### DIFF
--- a/scripts/scripts/flexrex
+++ b/scripts/scripts/flexrex
@@ -259,7 +259,6 @@ unmount() {
 		err "{ \"status\": \"Failed\", \"message\": \"Failed to unmount volume at ${MNTPATH}\"}"
 		exit 1
 	fi
-	rmdir "${MNTPATH}" > /dev/null 2>&1
 	success
 }
 


### PR DESCRIPTION
The FlexVolume [example](https://github.com/kubernetes/kubernetes/blob/master/examples/volumes/flexvolume/lvm)  mistakenly shows rmdir as part of the flexvolume script unmount logic. This is actually handled by a different function found [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/flexvolume/flexvolume.go#L374).

This quick fix simply removes the rmdir from out workflow, as it caused cleanup issues for kubernetes.