### PR TITLE
REX-Ray EBS Docker Plug-in

### DIFF
--- a/.docker/plugins/.gitignore
+++ b/.docker/plugins/.gitignore
@@ -1,0 +1,5 @@
+/*/Dockerfile
+/*/rexray.sh
+/*/rexray.yml
+/.travis-*.json
+/*/rexray

--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos
+
+LABEL drivers="${DRIVERS}"
+LABEL version="${VERSION}"
+
+RUN yum update -y
+RUN yum install xfsprogs e2fsprogs -y
+
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+ADD rexray /usr/bin/rexray
+ADD rexray.yml /etc/rexray/rexray.yml
+
+ADD rexray.sh /rexray.sh
+RUN chmod +x /rexray.sh
+
+ENTRYPOINT [ "/rexray.sh", "rexray", "start", "-f" ]

--- a/.docker/plugins/ebs/README.md
+++ b/.docker/plugins/ebs/README.md
@@ -1,0 +1,1 @@
+# REX-Ray Docker Plug-in for Amazon EBS

--- a/.docker/plugins/ebs/config.json
+++ b/.docker/plugins/ebs/config.json
@@ -1,0 +1,88 @@
+{
+      "Args": {
+        "Description": "",
+        "Name": "",
+        "Settable": null,
+        "Value": null
+      },
+      "Description": "REX-Ray for Amazon EBS",
+      "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/ebs",
+      "Entrypoint": [
+        "/rexray.sh", "rexray", "start", "-f"
+      ],
+      "Env": [
+        {
+          "Description": "",
+          "Name": "REXRAY_FSTYPE",
+          "Settable": [
+            "value"
+          ],
+          "Value": "ext4"
+        },
+        {
+          "Description": "",
+          "Name": "REXRAY_LOGLEVEL",
+          "Settable": [
+            "value"
+          ],
+          "Value": "warn"
+        },
+        {
+          "Description": "",
+          "Name": "REXRAY_PREEMPT",
+          "Settable": [
+            "value"
+          ],
+          "Value": "false"
+        },
+        {
+          "Description": "",
+          "Name": "EBS_ACCESSKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_REGION",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_SECRETKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        }
+      ],
+      "Interface": {
+        "Socket": "rexray.sock",
+        "Types": [
+          "docker.volumedriver/1.0"
+        ]
+      },
+      "Linux": {
+        "AllowAllDevices": true,
+        "Capabilities": ["CAP_SYS_ADMIN"],
+        "Devices": null
+      },
+      "Mounts": [
+        {
+          "Source": "/dev",
+          "Destination": "/dev",
+          "Type": "bind",
+          "Options": ["rbind"]
+        }
+      ],
+      "Network": {
+        "Type": "host"
+      },
+      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "User": {},
+      "WorkDir": ""
+}

--- a/.docker/plugins/rexray.sh
+++ b/.docker/plugins/rexray.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1:0:1}" = '-' ]; then
+	set -- rexray start -f "$@"
+fi
+
+#set default rexray options
+REXRAY_FSTYPE="${REXRAY_FSTYPE:-ext4}"
+REXRAY_LOGLEVEL="${REXRAY_LOGLEVEL:-warn}"
+REXRAY_PREEMPT="${REXRAY_PREEMPT:-false}"
+
+if [ "$1" = 'rexray' ]; then
+
+	for rexray_option in \
+		fsType \
+		loglevel \
+		preempt \
+	; do
+		var="REXRAY_${rexray_option^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			sed -ri 's/^([\ ]*'"$rexray_option"':).*/\1 '"$val"'/' /etc/rexray/rexray.yml
+		fi
+	done
+
+fi
+
+exec "$@"

--- a/.docker/plugins/rexray.yml
+++ b/.docker/plugins/rexray.yml
@@ -1,0 +1,12 @@
+rexray:
+  loglevel: warn
+libstorage:
+  service: ${DRIVERS}
+  integration:
+    volume:
+      operations:
+        create:
+          default:
+            fsType: ext4
+        mount:
+          preempt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 go_import_path: github.com/codedellemc/rexray
 
+sudo: required
+
+services:
+  - docker
+
 language: go
 
 go:
   - 1.7.5
-  - 1.6.3
   - tip
 
 env:
@@ -12,38 +16,42 @@ env:
   - REXRAY_BUILD_TYPE=client
   - REXRAY_BUILD_TYPE=agent
   - REXRAY_BUILD_TYPE=controller
+  - REXRAY_BUILD_TYPE= DRIVERS=ebs
 
 matrix:
   allow_failures:
-    - go:  1.6.3
     - go:  tip
   fast_finish: true
 
 before_install:
+  - if [ "$DRIVERS" != "" ]; then sudo apt-get update; fi
+  - if [ "$DRIVERS" != "" ]; then sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine; fi
+  - if [ "$DRIVERS" != "" ]; then docker --version; fi
   - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'
   - git config --global 'url.https://gopkg.in/yaml.v2.insteadof' 'https://gopkg.in/yaml.v2/'
   - git config --global 'url.https://gopkg.in/fsnotify.v1.insteadof' 'https://gopkg.in/fsnotify.v1/'
   - git config --global 'url.https://github.com/.insteadof' 'git://github.com/'
   - git config --global 'url.https://github.com/.insteadof' 'git@github.com:'
-  - go get github.com/onsi/gomega
-  - go get github.com/onsi/ginkgo
-  - go get golang.org/x/tools/cmd/cover
+  - if [ "$DRIVERS" = "" ]; then go get github.com/onsi/gomega; fi
+  - if [ "$DRIVERS" = "" ]; then go get github.com/onsi/ginkgo; fi
+  - if [ "$DRIVERS" = "" ]; then go get golang.org/x/tools/cmd/cover; fi
   - make deps
   - make info
 
 script:
   - make gometalinter-all
   - make -j build-libstorage
-  - env GOOS=linux GOARCH=amd64 make -j build
+  - GOOS=linux GOARCH=amd64 make -j build
   - if [ "$REXRAY_BUILD_TYPE" = "" ]; then REXRAY_DEBUG=true $GOPATH/bin/rexray version; else REXRAY_DEBUG=true $GOPATH/bin/rexray-$REXRAY_BUILD_TYPE version; fi
   - make -j test
+  - if [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make build-docker-plugin-${DRIVERS}; fi
 
 after_success:
-  - make -j cover
-  - if [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make tgz; fi
-  - if [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make rpm; fi
-  - if [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make deb; fi
-  - if [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make bintray; fi
+  - if [ "$DRIVERS" = "" ]; then make -j cover; fi
+  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make tgz; fi
+  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make rpm; fi
+  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make deb; fi
+  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make bintray; fi
   - ls -al
 
 deploy:


### PR DESCRIPTION
**Note:** As the label indicates, this is a work-in-progress and is being submitted as PR in order to provide the ability to centralize solicited feedback from other engineers, such as @codenrhoden, with regards to the build process.

This patch introduces the first Docker 1.13 plug-in, REX-Ray for Amazon EBS. The name of the Docker plug-in will be _rexray/ebs_ and all future Docker storage plug-ins based on REX-Ray will adhere to the same pattern - _rexray\/_**driver**.

Due to Travis-CI's inability to take advantage of Docker when using container builds coupled with non-container builds being so much slower, the inclusion of support for automated Docker plug-in builds will rely on enqueuing custom Travis-CI jobs at the end of a successful build.

All Docker plug-in-related material is found in the `.docker/plugins` subdirectory. Several common files are in the `.docker/plugins` directory and are copied or copied with sed into the `.docker/plugins/driver` directory at build time.