### PR TITLE
Updated libStorage Dependency

### DIFF
--- a/glide-docker.yaml
+++ b/glide-docker.yaml
@@ -10,7 +10,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: ad5dbe049c77f08ce84ce475637c5bf821f689b6 # libstorage-version
+    version: 4f8b9c6ccf9cee90b20e670659edf863ee32c370 # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c56967433017ec4fac6dcee7c253ced57e0627463612479021768e3c507ec317
-updated: 2017-02-09T18:05:23.673336537-06:00
+hash: c380528ee32eda8ba09fa3b796ac7265ffb760219f67ae1c3af062dd8a298630
+updated: 2017-02-11T12:11:28.85373544-06:00
 imports:
 - name: github.com/akutz/gofig
   version: 862741cad5edced279c57d1981e8e3e9fa54e8d5
@@ -79,7 +79,7 @@ imports:
   subpackages:
   - logrus
 - name: github.com/codedellemc/libstorage
-  version: ad5dbe049c77f08ce84ce475637c5bf821f689b6
+  version: 4f8b9c6ccf9cee90b20e670659edf863ee32c370
   repo: https://github.com/codedellemc/libstorage
   subpackages:
   - api

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: ad5dbe049c77f08ce84ce475637c5bf821f689b6 # libstorage-version
+    version: 4f8b9c6ccf9cee90b20e670659edf863ee32c370 # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig


### PR DESCRIPTION
This patch updates the libStorage dependency to the latest commit on the libStorage's release branch `release/0.5.0`.