### PR TITLE
Enhanced Docker Plug-in Builds

### DIFF
--- a/.docker/plugins/rexray.yml
+++ b/.docker/plugins/rexray.yml
@@ -1,7 +1,6 @@
 rexray:
   loglevel: warn
 libstorage:
-  service: ${DRIVERS}
   integration:
     volume:
       operations:
@@ -10,3 +9,5 @@ libstorage:
             fsType: ext4
         mount:
           preempt: true
+  server:
+    services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - GOOS=linux GOARCH=amd64 make -j build
   - if [ "$REXRAY_BUILD_TYPE" = "" ]; then REXRAY_DEBUG=true $GOPATH/bin/rexray version; else REXRAY_DEBUG=true $GOPATH/bin/rexray-$REXRAY_BUILD_TYPE version; fi
   - make -j test
-  - if [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make build-docker-plugin-${DRIVERS}; fi
+  - if [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make build-docker-plugin; fi
 
 after_success:
   - if [ "$DRIVERS" = "" ]; then make -j cover; fi


### PR DESCRIPTION
This patch provides the ability to create Docker plug-ins with multiple drivers. Simply use `DRIVERS="ebs scaleio efs" make build-docker-plugin` and voila. The one requirement is that a directory must exist for the provided driver list with dash `-` characters in place of the spaces at `.docker/plugins/DRIVERS`. For example, for the previous example the directory would be `.docker/plugins/ebs-scaleio-efs`. Inside that directory there should be a file named `config.json` which is the plug-in's configuration file. The REX-Ray configuration file and its multiple services for each driver is generated with the Makefile target.