### PR TITLE
Alpine-Based Docker Plug-in / S3FS Plug-in

### DIFF
--- a/.docker/plugins/.gitignore
+++ b/.docker/plugins/.gitignore
@@ -1,5 +1,0 @@
-/*/Dockerfile
-/*/rexray.sh
-/*/rexray.yml
-/.travis-*.json
-/*/rexray

--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -1,11 +1,12 @@
-FROM centos
+FROM alpine:3.5
 
 LABEL drivers="${DRIVERS}"
 LABEL version="${VERSION}"
 
-RUN yum update -y
-RUN yum install xfsprogs e2fsprogs -y
+RUN apk update
+RUN apk add xfsprogs e2fsprogs ca-certificates
 
+RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml

--- a/.docker/plugins/ebs/.gitignore
+++ b/.docker/plugins/ebs/.gitignore
@@ -1,0 +1,5 @@
+/Dockerfile
+/rexray.sh
+/rexray.yml
+/rexray
+/rootfs/

--- a/.docker/plugins/rexray.sh
+++ b/.docker/plugins/rexray.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/ash
+# shellcheck shell=dash
 set -e
 
 # first arg is `-f` or `--some-option`
-if [ "${1:0:1}" = '-' ]; then
+if [ "$(echo "$1" | \
+	awk  '{ string=substr($0, 1, 1); print string; }' )" = '-' ]; then
 	set -- rexray start -f "$@"
 fi
 
@@ -18,10 +20,11 @@ if [ "$1" = 'rexray' ]; then
 		loglevel \
 		preempt \
 	; do
-		var="REXRAY_${rexray_option^^}"
-		val="${!var}"
+		val=$(eval echo "\$REXRAY_$(echo $rexray_option | \
+			awk '{print toupper($0)}')")
 		if [ "$val" ]; then
-			sed -ri 's/^([\ ]*'"$rexray_option"':).*/\1 '"$val"'/' /etc/rexray/rexray.yml
+			sed -ri 's/^([\ ]*'"$rexray_option"':).*/\1 '"$val"'/' \
+				/etc/rexray/rexray.yml
 		fi
 	done
 

--- a/.docker/plugins/rexray.yml
+++ b/.docker/plugins/rexray.yml
@@ -1,6 +1,7 @@
 rexray:
   loglevel: warn
 libstorage:
+  service: ${DRIVERS}
   integration:
     volume:
       operations:

--- a/.docker/plugins/s3fs/.gitignore
+++ b/.docker/plugins/s3fs/.gitignore
@@ -1,0 +1,5 @@
+/Dockerfile
+/rexray.sh
+/rexray.yml
+/rexray
+/rootfs/

--- a/.docker/plugins/s3fs/README.md
+++ b/.docker/plugins/s3fs/README.md
@@ -1,0 +1,1 @@
+# REX-Ray Docker Plug-in for Amazon S3FS

--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -1,0 +1,88 @@
+{
+      "Args": {
+        "Description": "",
+        "Name": "",
+        "Settable": null,
+        "Value": null
+      },
+      "Description": "REX-Ray for Amazon S3FS",
+      "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/s3fs",
+      "Entrypoint": [
+        "/rexray.sh", "rexray", "start", "-f"
+      ],
+      "Env": [
+        {
+          "Description": "",
+          "Name": "REXRAY_FSTYPE",
+          "Settable": [
+            "value"
+          ],
+          "Value": "ext4"
+        },
+        {
+          "Description": "",
+          "Name": "REXRAY_LOGLEVEL",
+          "Settable": [
+            "value"
+          ],
+          "Value": "warn"
+        },
+        {
+          "Description": "",
+          "Name": "REXRAY_PREEMPT",
+          "Settable": [
+            "value"
+          ],
+          "Value": "false"
+        },
+        {
+          "Description": "",
+          "Name": "S3FS_ACCESSKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "S3FS_REGION",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "S3FS_SECRETKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        }
+      ],
+      "Interface": {
+        "Socket": "rexray.sock",
+        "Types": [
+          "docker.volumedriver/1.0"
+        ]
+      },
+      "Linux": {
+        "AllowAllDevices": true,
+        "Capabilities": ["CAP_SYS_ADMIN"],
+        "Devices": null
+      },
+      "Mounts": [
+        {
+          "Source": "/dev",
+          "Destination": "/dev",
+          "Type": "bind",
+          "Options": ["rbind"]
+        }
+      ],
+      "Network": {
+        "Type": "host"
+      },
+      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "User": {},
+      "WorkDir": ""
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/sio-alpine.sh
 *.*-e
 .*-e
 *-e

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - REXRAY_BUILD_TYPE=agent
   - REXRAY_BUILD_TYPE=controller
   - REXRAY_BUILD_TYPE= DRIVERS=ebs
+  - REXRAY_BUILD_TYPE= DRIVERS=s3fs
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -1133,7 +1133,8 @@ SPACE6 := $(SPACE)$(SPACE)$(SPACE)$(SPACE)$(SPACE)$(SPACE)
 SPACE8 := $(SPACE6)$(SPACE)$(SPACE)
 DOCKER_PLUGIN_CONFIGFILE_TGT := $(DOCKER_PLUGIN_BUILD_PATH)/$(PROG).yml
 $(DOCKER_PLUGIN_CONFIGFILE_TGT): $(DOCKER_PLUGIN_CONFIGFILE)
-	cp $? $@
+	sed -e 's/$${DRIVERS}/$(firstword $(DRIVERS))/g' \
+	    $? > $@
 	for d in $(DRIVERS); do \
 	    echo "$(SPACE6)$$d:" >> $@; \
 	    echo "$(SPACE8)driver: $$d" >> $@; \


### PR DESCRIPTION
This patch switches the Docker plug-in image to be based on Alpine as well as introduces an S3FS plug-in skeleton. This relates to issue #719. 

This issue is also a work-in-progress, or it may also simply be rebased to no longer include the S3FS support as that presents its own challenges with including a working `s3fs` binary. While there [is a project](https://github.com/rjocoleman/docker-alpine-s3fs) that outlines how to build an Alpine-based image with `s3fs`, it does not work. The system complains that the `fuse` module is unable to be loaded or located by `modprobe` and when attempting to mount the bucket with the `s3fs` binary. So far no research has uncovered a solution.