### PR TITLE
Push Docker Plug-ins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,17 @@ go:
   - tip
 
 env:
-  - REXRAY_BUILD_TYPE=
-  - REXRAY_BUILD_TYPE=client
-  - REXRAY_BUILD_TYPE=agent
-  - REXRAY_BUILD_TYPE=controller
-  - REXRAY_BUILD_TYPE= DRIVERS=ebs
-  - REXRAY_BUILD_TYPE= DRIVERS=s3fs
-  - REXRAY_BUILD_TYPE= DRIVERS=scaleio
+  global:
+    - secure: "gOb/232zSil9xWQDNTEkAtSGwAiOicGLyMlOAA6AVQySHQpkctpC4C3r6dqPsM5BLgm+URR9IztxzNUke1cy4jbRz8o/aocryDdt9OoC0eDS+LSH2aqtvtebXgTy1TVD3QEo1vkyNDweeTx6oZb5setAQq3L9L68wuijku6nOXw=" # DOCKER_USER
+    - secure: "YO6l1NOdaIguFbHHHbwAPFgXsIKDh61nGPEQHY6dFKGtkX2anB3THZ3ZsIHsmiuSjNiL+A1fHJqMq4+UBVxrEjpmhIR9oFCwKBVFLvMHSzs3cXQieMl5rhtVvUp5fks64Z1MfrxnvGpLNXqmfbyGFR5rMMTH/19q9lh3RPayprM=" # DOCKER_PASS
+  matrix:
+    - REXRAY_BUILD_TYPE=
+    - REXRAY_BUILD_TYPE=client
+    - REXRAY_BUILD_TYPE=agent
+    - REXRAY_BUILD_TYPE=controller
+    - REXRAY_BUILD_TYPE= DRIVERS=ebs
+    - REXRAY_BUILD_TYPE= DRIVERS=s3fs
+    - REXRAY_BUILD_TYPE= DRIVERS=scaleio
 
 matrix:
   allow_failures:
@@ -46,7 +50,6 @@ script:
   - GOOS=linux GOARCH=amd64 make -j build
   - if [ "$REXRAY_BUILD_TYPE" = "" ]; then REXRAY_DEBUG=true $GOPATH/bin/rexray version; else REXRAY_DEBUG=true $GOPATH/bin/rexray-$REXRAY_BUILD_TYPE version; fi
   - make -j test
-  - if [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make build-docker-plugin; fi
 
 after_success:
   - if [ "$DRIVERS" = "" ]; then make -j cover; fi
@@ -54,6 +57,7 @@ after_success:
   - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make rpm; fi
   - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make deb; fi
   - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make bintray; fi
+  - if [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make build-docker-plugin; fi
   - ls -al
 
 deploy:
@@ -64,7 +68,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
+      condition: $DISABLE_BINTRAY != true && $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
 
   - provider: bintray
     file: bintray-staged.json
@@ -73,7 +77,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $DISABLE_BINTRAY != true && $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
   - provider: bintray
     file: bintray-stable.json
@@ -82,7 +86,28 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $DISABLE_BINTRAY != true && $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+
+  - provider: script
+    script: make.sh push-docker-plugin unstable
+    skip_cleanup: true
+    on:
+      all_branches: true
+      condition: $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
+
+  - provider: script
+    script: make.sh push-docker-plugin staged
+    skip_cleanup: true
+    on:
+      all_branches: true
+      condition: $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+
+  - provider: script
+    script: make.sh push-docker-plugin stable
+    skip_cleanup: true
+    on:
+      all_branches: true
+      condition: $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_GO_VERSION = $COVERED_GO_VERSION && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
 cache:
   apt: true

--- a/Makefile
+++ b/Makefile
@@ -1182,6 +1182,28 @@ $(DOCKER_PLUGIN_ENTRYPOINT_ROOTFS_TGT): $(DOCKER_PLUGIN_CONFIGJSON_TGT) \
 	docker plugin ls
 
 
+push-docker-plugin: $(DOCKER_PLUGIN_ENTRYPOINT_ROOTFS_TGT)
+ifneq (,$(strip $(DOCKER_USER)))
+ifneq (,$(strip $(DOCKER_PASS)))
+	docker login -u $(DOCKER_USER) -p $(DOCKER_PASS)
+endif
+endif
+ifeq (unstable,$(DOCKER_PLUGIN_TYPE))
+	docker build -t $(PROG)/$(DOCKER_PLUGIN_DRIVERS):unstable $$(dirname $(@D))
+	docker plugin push $(PROG)/$(DOCKER_PLUGIN_DRIVERS):unstable
+endif
+ifeq (staged,$(DOCKER_PLUGIN_TYPE))
+	docker plugin push $(DOCKER_PLUGIN_NAME)
+endif
+ifeq (stable,$(DOCKER_PLUGIN_TYPE))
+	docker plugin push $(DOCKER_PLUGIN_NAME)
+	docker build -t $(PROG)/$(DOCKER_PLUGIN_DRIVERS):latest $$(dirname $(@D))
+	docker plugin push $(PROG)/$(DOCKER_PLUGIN_DRIVERS):latest
+endif
+ifeq (,$(DOCKER_PLUGIN_TYPE))
+	docker plugin push $(DOCKER_PLUGIN_NAME)
+endif
+
 ################################################################################
 ##                                PROG Markers                                ##
 ################################################################################

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$1" = "push-docker-plugin" ]; then
+    DOCKER_PLUGIN_TYPE=$2 exec make push-docker-plugin
+fi
+
+exec make "$@"


### PR DESCRIPTION
This patch updates the build process to push Docker plug-ins during the deploy phase of the build with the following conditions and expected results:

* Builds on the `master` branch will push a plug-in named `rexray/driver:unstable`.

* Annotated, tagged builds that match an RC tag will push a plug-in named `rexray/driver:semver`.

* Annotated, tagged builds that match a GA tag will push two plug-ins named `rexray/driver:latest` and `rexray/driver:semver`.