### PR TITLE
Add libStorage to make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -869,6 +869,10 @@ else
 build-libstorage: $(LIBSTORAGE_API)
 endif
 
+clean-libstorage:
+	$(MAKE) -C $(LIBSTORAGE_DIR) clean
+GO_CLEAN += clean-libstorage
+GO_PHONY += clean-libstorage
 
 ################################################################################
 ##                                 SCRIPTS                                    ##


### PR DESCRIPTION
This patch adds `make -C libstorage clean` to the clean target so that vendored libStorage artifacts are cleaned by default. This solves issue #751.