### PR TITLE
PID Chaos in Docker Plug-in

### DIFF
--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -14,4 +14,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-ENTRYPOINT [ "/rexray.sh", "rexray", "start", "-f" ]
+CMD [ "rexray", "start", "-f", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/ebs/config.json
+++ b/.docker/plugins/ebs/config.json
@@ -8,7 +8,7 @@
       "Description": "REX-Ray for Amazon EBS",
       "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/ebs",
       "Entrypoint": [
-        "/rexray.sh", "rexray", "start", "-f"
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
       ],
       "Env": [
         {

--- a/.docker/plugins/efs/.Dockerfile
+++ b/.docker/plugins/efs/.Dockerfile
@@ -14,4 +14,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-ENTRYPOINT [ "/rexray.sh", "rexray", "start", "-f" ]
+CMD [ "rexray", "start", "-f", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/efs/config.json
+++ b/.docker/plugins/efs/config.json
@@ -8,7 +8,7 @@
       "Description": "REX-Ray for Amazon EFS",
       "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/efs",
       "Entrypoint": [
-        "/rexray.sh", "rexray", "start", "-f"
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
       ],
       "Env": [
         {

--- a/.docker/plugins/gcepd/config.json
+++ b/.docker/plugins/gcepd/config.json
@@ -8,7 +8,7 @@
       "Description": "REX-Ray for GCE Persistent Disks",
       "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/gcepd",
       "Entrypoint": [
-        "/rexray.sh", "rexray", "start", "-f"
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
       ],
       "Env": [
         {

--- a/.docker/plugins/isilon/.Dockerfile
+++ b/.docker/plugins/isilon/.Dockerfile
@@ -14,4 +14,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-ENTRYPOINT [ "/rexray.sh", "rexray", "start", "-f" ]
+CMD [ "rexray", "start", "-f", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/isilon/config.json
+++ b/.docker/plugins/isilon/config.json
@@ -8,7 +8,7 @@
       "Description": "REX-Ray for Dell EMC Isilon",
       "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/isilon",
       "Entrypoint": [
-        "/rexray.sh", "rexray", "start", "-f"
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
       ],
       "Env": [
         {
@@ -52,7 +52,7 @@
           "Value": ""
         },
         {
-          "Description": "", 
+          "Description": "",
           "Name": "ISILON_PASSWORD",
           "Settable": [
             "value"
@@ -60,7 +60,7 @@
           "Value": ""
         },
         {
-          "Description": "", 
+          "Description": "",
           "Name": "ISILON_VOLUMEPATH",
           "Settable": [
             "value"
@@ -68,7 +68,7 @@
           "Value": ""
         },
         {
-          "Description": "", 
+          "Description": "",
           "Name": "ISILON_NFSHOST",
           "Settable": [
             "value"
@@ -76,7 +76,7 @@
           "Value": ""
         },
         {
-          "Description": "", 
+          "Description": "",
           "Name": "ISILON_DATASUBNET",
           "Settable": [
             "value"
@@ -84,7 +84,7 @@
           "Value": ""
         },
         {
-          "Description": "", 
+          "Description": "",
           "Name": "ISILON_QUOTAS",
           "Settable": [
             "value"

--- a/.docker/plugins/rexray.sh
+++ b/.docker/plugins/rexray.sh
@@ -5,7 +5,7 @@ set -e
 # first arg is `-f` or `--some-option`
 if [ "$(echo "$1" | \
 	awk  '{ string=substr($0, 1, 1); print string; }' )" = '-' ]; then
-	set -- rexray start -f "$@"
+	set -- rexray start -f --nopid "$@"
 fi
 
 #set default rexray options

--- a/.docker/plugins/s3fs/.Dockerfile
+++ b/.docker/plugins/s3fs/.Dockerfile
@@ -19,4 +19,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-ENTRYPOINT [ "/rexray.sh", "rexray", "start", "-f" ]
+CMD [ "rexray", "start", "-f", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -8,7 +8,7 @@
       "Description": "REX-Ray for Amazon S3FS",
       "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/s3fs",
       "Entrypoint": [
-        "/rexray.sh", "rexray", "start", "-f"
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
       ],
       "Env": [
         {

--- a/.docker/plugins/scaleio/.Dockerfile
+++ b/.docker/plugins/scaleio/.Dockerfile
@@ -22,4 +22,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-ENTRYPOINT [ "/rexray.sh", "rexray", "start", "-f" ]
+CMD [ "rexray", "start", "-f", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/scaleio/config.json
+++ b/.docker/plugins/scaleio/config.json
@@ -8,7 +8,7 @@
       "Description": "REX-Ray for Dell EMC ScaleIO",
       "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/scaleio",
       "Entrypoint": [
-        "/rexray.sh", "rexray", "start", "-f"
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
       ],
       "Env": [
         {

--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -105,6 +105,7 @@ type CLI struct {
 	outputTemplate          string
 	outputTemplateTabs      bool
 	fg                      bool
+	nopid                   bool
 	fork                    bool
 	force                   bool
 	cfgFile                 string

--- a/cli/cli/cmds_04_service.go
+++ b/cli/cli/cmds_04_service.go
@@ -79,6 +79,8 @@ func (c *CLI) initServiceCmds() {
 func (c *CLI) initServiceFlags() {
 	c.serviceStartCmd.Flags().BoolVarP(&c.fg, "foreground", "f", false,
 		"Starts the service in the foreground")
+	c.serviceStartCmd.Flags().BoolVarP(&c.nopid, "nopid", "", false,
+		"Disable PID file checking")
 	c.serviceStartCmd.Flags().BoolVarP(&c.force, "force", "", false,
 		"Forces the service to start, ignoring errors")
 	c.serviceStartCmd.Flags().BoolVarP(&c.fork, "fork", "", false,


### PR DESCRIPTION
This patch fixes an issue where a stale PID file used by REX-Ray is never properly removed and locks the program due to the Docker plug-in model of fast-restarting a plug-in if misconfigured combined with the entry point always using PID 1.

Additionally, this patch updates the `Dockerfile`s so that the entrypoint is now defined with default arguments that can be overridden via the CLI for test and development purposes.