### PR TITLE
Fix allowing encrypted volumes

### DIFF
--- a/daemon/module/docker/volumedriver/voldriver.go
+++ b/daemon/module/docker/volumedriver/voldriver.go
@@ -202,6 +202,7 @@ func (m *mod) buildMux() *http.ServeMux {
 		if vtype == nil {
 			vtype = store.GetStringPtr("volumetype")
 		}
+		encrypted := store.GetBoolPtr("encrypted")
 		_, err := m.lsc.Integration().Create(
 			m.ctx,
 			pr.Name,
@@ -210,6 +211,7 @@ func (m *mod) buildMux() *http.ServeMux {
 				IOPS:             store.GetInt64Ptr("iops"),
 				Size:             store.GetInt64Ptr("size"),
 				Type:             vtype,
+				Encrypted:        encrypted,
 				Opts:             store,
 			})
 


### PR DESCRIPTION
An issue discovered from a user in the slack community. The encrypted flag was not being passed to libstorage correctly. This is a API as seen from dvdcli and rexray cli below. This fixes the issue.

REX-Ray CLI
 ```
{
    "name": "rexray",
    "availabilityZone": "",
    "encrypted": true,
    "iops": 0,
    "size": 1,
    "type": ""
}
```

DVDCLI
```
{
    "name": "dvdcli",
    "availabilityZone": "",
    "iops": 0,
    "size": 5,
    "type": "gp2",
    "opts": {
        "encrypted": "true",
        "size": "5",
        "volumetype": "gp2"
    }
}
```