### PR TITLE
Use upstream Cobra package

### DIFF
--- a/cli/cli/cmds_00_other.go
+++ b/cli/cli/cmds_00_other.go
@@ -69,8 +69,8 @@ func (c *CLI) initOtherCmds() {
 }
 
 func (c *CLI) initOtherFlags() {
-	cobra.HelpFlagShorthand = "?"
-	cobra.HelpFlagUsageFormatString = "Help for %s"
+	c.c.PersistentFlags().BoolP("help", "?", false,
+		"Help about the current command")
 
 	c.c.PersistentFlags().StringVarP(&c.cfgFile, "config", "c", "",
 		"The path to a custom REX-Ray configuration file")

--- a/cli/cli/usage.go
+++ b/cli/cli/usage.go
@@ -161,7 +161,7 @@ Aliases:
 Examples:
 {{.Example | rtrim}}{{end}}{{ if .HasAvailableSubCommands}}
 
-Available Commands: {{range cmds $cmd}}{{if (not .IsHelpCommand)}}
+Available Commands: {{range cmds $cmd}}{{if (not .IsAdditionalHelpTopicCommand)}}
   {{rpad .Name .NamePadding }} {{.Short | rtrim}}{{end}}{{end}}{{end}}{{$lf := lf $cmd}}{{if hf $lf}}
 
 Flags:
@@ -174,7 +174,7 @@ Global Flags:
 {{$fs.FlagUsages | rtrim}}
 {{end}}{{end}}{{if .HasHelpSubCommands}}
 
-Additional help topics: {{range .Commands}}{{if .IsHelpCommand}}
+Additional help topics: {{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short | rtrim}}{{end}}}{{end}}{{end}}{{if .HasSubCommands}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}

--- a/glide-docker.yaml
+++ b/glide-docker.yaml
@@ -24,11 +24,9 @@ import:
     version: v0.1.0
 
   - package: github.com/spf13/pflag
-    ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
-    repo:    https://github.com/spf13/pflag
+    ref:     d16db1e50e33dff1b6cdf37596cef36742128670
   - package: github.com/spf13/cobra
-    ref:     363816bb13ce1710460c2345017fd35593cbf5ed
-    repo:    https://github.com/akutz/cobra
+    ref:     7be4beda01ec05d0b93d80b3facd2b6f44080d94
   - package: golang.org/x/net
     repo:    https://github.com/golang/net
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 35113c02c0fb913e440780ba5e0590ef88ba132a21c3f895beb77869d3cf862b
-updated: 2017-03-28T14:21:50.729273278-05:00
+hash: 2f83cdcffda2c664b856d5d79927eb548124f57574f8ccf3e675338d8a459e1c
+updated: 2017-03-29T11:30:02.898046438-07:00
 imports:
 - name: cloud.google.com/go
   version: e4de3dc4493f142c5833f3185e1182025a61f805
@@ -25,7 +25,7 @@ imports:
   - vboxwebsrv
   - virtualboxclient
 - name: github.com/asaskevich/govalidator
-  version: fdf19785fd3558d619ef81212f5edf1d6c2a5911
+  version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/aws/aws-sdk-go
   version: 3f8f870ec9939e32b3372abf74d24e468bcd285d
   repo: https://github.com/aws/aws-sdk-go
@@ -178,18 +178,14 @@ imports:
   - imports/local
   - imports/remote
   - imports/routers
-- name: github.com/cpuguy83/go-md2man
-  version: a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
-  subpackages:
-  - md2man
 - name: github.com/dgrijalva/jwt-go
   version: 2268707a8f0843315e2004ee4f1d021dc08baedf
 - name: github.com/digitalocean/godo
   version: 2ff8a02a86cd6918b384a5000ceebe886844fbce
 - name: github.com/fsnotify/fsnotify
-  version: a904159b9206978bb6d53fcc7a769e5cd726c737
+  version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
 - name: github.com/go-ini/ini
-  version: ee900ca565931451fe4e4409bcbd4316331cec1c
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/go-yaml/yaml
   version: bc35f417f8a7664a73d46c9def2933417c03019f
   repo: https://github.com/akutz/yaml.git
@@ -206,9 +202,9 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
 - name: github.com/hashicorp/hcl
-  version: 372e8ddaa16fd67e371e9323807d056b799360af
+  version: f74cf8281543a0797d7b4ab7d88e76e7ba125308
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -229,40 +225,41 @@ imports:
   version: 9b883c5eb462dd5cb1b0a7a104fe86bc6b9bd391
   repo: https://github.com/kardianos/osext.git
   vcs: git
+- name: github.com/kr/fs
+  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: b3b15ef068fd0b17ddf408a23669f20811d194d2
+  version: 0723e352fa358f9322c938cc2dadda874e9151a9
 - name: github.com/mitchellh/mapstructure
-  version: db1efb556f84b25a0a13a04aad883943538ad2e0
+  version: f3009df150dadf309fdee4a54ed65c124afad715
 - name: github.com/pelletier/go-buffruneio
   version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: c9506ee96398e7571356462217b9e24d6a628d71
+  version: 45932ad32dfdd20826f5671da37a5f3ce9f26a8d
+- name: github.com/pkg/errors
+  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+- name: github.com/pkg/sftp
+  version: 4d0e916071f68db74f8a73926335f809396d6b42
 - name: github.com/rubiojr/go-vhd
   version: 96a0db67ea8209453cfa694bdf03de202d6dd8f8
   repo: https://github.com/codenrhoden/go-vhd
   subpackages:
   - vhd
-- name: github.com/russross/blackfriday
-  version: 5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
-- name: github.com/shurcooL/sanitized_anchor_name
-  version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/Sirupsen/logrus
   version: 5f376aa629ac60c3215cc368e674bd996093a01a
   repo: https://github.com/akutz/logrus
 - name: github.com/spf13/afero
-  version: 72b31426848c6ef12a7a8e216708cb0d1530f074
+  version: 52e4a6cfac46163658bd4f123c49b6ee7dc75f78
   subpackages:
   - mem
+  - sftp
 - name: github.com/spf13/cast
-  version: d1139bab1c07d5ad390a65e7305876b3c1a8370b
+  version: 2580bc98dc0e62908119e4737030cc2fdfc45e4c
 - name: github.com/spf13/cobra
-  version: 363816bb13ce1710460c2345017fd35593cbf5ed
-  repo: https://github.com/akutz/cobra
+  version: 7be4beda01ec05d0b93d80b3facd2b6f44080d94
 - name: github.com/spf13/jwalterweatherman
-  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
+  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
-  version: b084184666e02084b8ccb9b704bf0d79c466eb1d
-  repo: https://github.com/spf13/pflag
+  version: d16db1e50e33dff1b6cdf37596cef36742128670
 - name: github.com/spf13/viper
   version: 651d9d916abc3c3d6a91a12549495caba5edffd2
 - name: github.com/tent/http-link-go
@@ -270,8 +267,12 @@ imports:
 - name: golang.org/x/crypto
   version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
   subpackages:
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
   - pkcs12
   - pkcs12/internal/rc2
+  - ssh
 - name: golang.org/x/net
   version: b336a971b799939dd16ae9b1df8334cb8b977c4d
   repo: https://github.com/golang/net
@@ -296,7 +297,7 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 06d6eba81293389cafdff7fca90d75592194b2d9
+  version: a8b38433e35b65ba247bb267317037dee1b70cea
   subpackages:
   - transform
   - unicode/norm

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,11 +24,9 @@ import:
     version: v0.1.0
 
   - package: github.com/spf13/pflag
-    ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
-    repo:    https://github.com/spf13/pflag
+    ref:     d16db1e50e33dff1b6cdf37596cef36742128670
   - package: github.com/spf13/cobra
-    ref:     363816bb13ce1710460c2345017fd35593cbf5ed
-    repo:    https://github.com/akutz/cobra
+    ref:     7be4beda01ec05d0b93d80b3facd2b6f44080d94
   - package: golang.org/x/net
     repo:    https://github.com/golang/net
 


### PR DESCRIPTION
We had been using a fork of Cobra to allow us to redefine the shorthand flag for hep (using "?" instead of "h"). The upstream package changed the way it auto-added the help flags that allows us to go back to using the upstream package now.

Switching to the upstream packages fixes #743.  The problem there was always that the help output implied that the boolean flag could be used as either true *or* false. In reality, we default to false, and only take action when set to true. Explicitly setting to false is not intended to affect a behavior.

Before this change:

```
rexray help volume ls
....
Flags:
      --attached[=false]: A flag that indicates only volumes attached to this host should be returned
      --available[=false]: A flag that indicates only available volumes should be returned
      --path[=false]: A flag that indicates only volumes attached to this host should be returned, along with their path info
...
```

After:

```
rexray help volume ls
...
Flags:
      --attached    A flag that indicates only volumes attached to this host should be returned
      --available   A flag that indicates only available volumes should be returned
      --path        A flag that indicates only volumes attached to this host should be returned, along with their path info
...
```