### PR TITLE
Detect old and new still CoreOS distro name

### DIFF
--- a/install
+++ b/install
@@ -62,7 +62,7 @@ sudo() {
 }
 
 is_coreos() {
-    grep DISTRIB_ID=CoreOS /etc/lsb-release 2> /dev/null
+    grep DISTRIB_ID /etc/lsb-release 2> /dev/null | grep CoreOS 2> /dev/null
 }
 
 list() {


### PR DESCRIPTION
This patch modifies the installs script to look for any version of `CoreOS` in the `DISTRIB_ID` line of `/etc/lsb_release`, which will work on old versions of CoreOS and new.

FIxes #793 