### PR TITLE
Service Dependencies

### DIFF
--- a/cli/cli/installer.go
+++ b/cli/cli/installer.go
@@ -328,6 +328,9 @@ KillMode=process
 
 [Install]
 WantedBy=docker.service
+Wants=scini.service
+Before=docker.service
+After=scini.service
 `
 
 func createInitFile() {
@@ -365,6 +368,8 @@ const initScriptTemplate = `### BEGIN INIT INFO
 # Provides:          {{.BinFileName}}
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
+# Should-Start:      scini
+# X-Start-Before:    docker
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start daemon at boot time


### PR DESCRIPTION
This patch handles issue #587 and introduces new service dependencies to ensure that the ScaleIO service is started before REX-Ray and that Docker starts after REX-Ray.

SystemD options found [here](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) and SystemV/LSB options [here](https://wiki.debian.org/LSBInitScripts).