### PR TITLE
Update FlexREX for k8s 1.6

### DIFF
--- a/.docs/about/release-notes.md
+++ b/.docs/about/release-notes.md
@@ -102,7 +102,7 @@ storage platform.
 * Ceph/RBD storage platform ([#347](https://github.com/codedellemc/libstorage/pull/347))
 
 ### Bug Fixes
-* Prevent unnecessary removal of directory by FlexRex ([#699](https://github.com/codedellemc/rexray/pull/699))
+* Prevent unnecessary removal of directory by FlexREX ([#699](https://github.com/codedellemc/rexray/pull/699))
 * Update `volume attach` to check for `--force` flag ([#696](https://github.com/codedellemc/rexray/pull/696))
 * Fix installer to correctly parse new Bintray HTML ([#687](https://github.com/codedellemc/rexray/pull/687))
 

--- a/.docs/user-guide/schedulers.md
+++ b/.docs/user-guide/schedulers.md
@@ -159,15 +159,16 @@ configuring popular applications with persistent storage via Docker and REX-Ray.
 REX-Ray can be integrated with [Kubernetes](https://kubernetes.io/) allowing
 pods to consume data stored on volumes that are orchestrated by REX-Ray. Using
 Kubernetes' [FlexVolume](https://kubernetes.io/docs/user-guide/volumes/#flexvolume)
-plug-in, REX-Ray can provide uniform access to storage operatations such as attach,
+plug-in, REX-Ray can provide uniform access to storage operations such as attach,
 mount, detach, and unmount for any configured storage provider.  REX-Ray provides an
-adapter script called `FlexRex` which integrates with the FlexVolume to interact
+adapter script called `FlexREX` which integrates with the FlexVolume to interact
 with the backing storage system.
 
 ### Pre-Requisites
 - [Kubernetes](https://kubernetes.io/) 1.5 or higher
 - REX-Ray 0.7 or higher
 - [jq binary](https://stedolan.github.io/jq/)
+- Kubernetes kubelets must be running with `enable-controller-attach-detach` disabled
 
 ### Installation
 It is assumed that you have a Kubernetes cluster at your disposal. On each
@@ -189,14 +190,14 @@ If there is no issue, you should see an output, similar to above, which shows
 a list of previously created volumes. If instead you get an error,  
 ensure that REX-Ray is properly configured for the intended storage system.
 
-Next, using the REX-Ray binary,  install the `FlexRex` adapter script on the node
+Next, using the REX-Ray binary,  install the `FlexREX` adapter script on the node
 as shown below.  
 
 ```
 # rexray flexrex install
 ```
 
-This should produce the following output showing that the FlexRex script is
+This should produce the following output showing that the FlexREX script is
 installed successfully:
 
 ```
@@ -206,19 +207,23 @@ Path                                                                        Inst
 
 The path shown above is the default location where the FlexVolume plug-in will
 expect to find its integration code.  If you are not using the default location
-with FlexVolume, you can install the  `FlexRex` in an arbitrary location using:
+with FlexVolume, you can install the  `FlexREX` in an arbitrary location using:
 
 ```
 # rexray flexrex install --path /opt/plug-ins/rexray~flexrex/flexrex
 ```
 
-Next, restart the kublet process on the node:
+!!! note
+    FlexREX requires that the `enable-controller-attach-detach` flag for the
+    kubelet is set to False.
+
+Next, restart the kubelet process on the node:
 
 ```
 # systemctl restart kubelet
 ```
 
-You can validate that the FlexRex script has been started successfully by searching
+You can validate that the `FlexREX` script has been started successfully by searching
 the kubelet log for an entry similar to the following:
 
 ```
@@ -227,12 +232,12 @@ I0208 10:56:57.412207    5348 plug-ins.go:350] Loaded volume plug-in "rexray/fle
 
 ### Pods and Persistent Volumes
 You can now deploy pods and persistent volumes that use storage systems orchestrated
-by REX-Ray.  It is worth pointing out that the Kubernetes FlexVolme plug-in can only
-attach volumes that already exist in the storge system.  Any volume that is to be used
+by REX-Ray.  It is worth pointing out that the Kubernetes FlexVolume plug-in can only
+attach volumes that already exist in the storage system.  Any volume that is to be used
 by a Kubernetes resource must be listed in a `rexray volume ls` command.
 
 #### Pod with REX-Ray volume
-The following YAML file shows the definition of a pod that uses FlexRex to attach a volume
+The following YAML file shows the definition of a pod that uses `FlexREX` to attach a volume
 to be used by the pod.
 
 ```
@@ -263,8 +268,8 @@ Additional options can be provided in the `options:` as follows:
 
 Option|Desription
 ------|----------
-volumeID|Reference name of the volume in REX-Ray
-forceAttach|When true ensures the volume is availble before attahing (optinal, defaults to false)
+volumeID|Reference name of the volume in REX-Ray (Required)
+forceAttach|When true ensures the volume is available before attaching (optional, defaults to false)
 forceAttachDelay|Total amount of time (in sec) to attempt attachment with 5 sec interval between tries (optional)
 
 #### REX-Ray PersistentVolume

--- a/scripts/scripts/flexrex
+++ b/scripts/scripts/flexrex
@@ -21,8 +21,23 @@
 #  - Please install "jq" package before using this driver.
 #  - Please install and configure REX-Ray before using this driver
 
+# stderr
 err() {
+	debug "failure status" "$*"
 	printf "%b" "$*" 1>&2
+}
+
+# stdout
+log() {
+	debug "success status" "$*"
+	printf "%b" "$*" >&1
+}
+
+# log file
+debug() {
+	if [ "$FLEXREX_DEBUG" = "1" ]; then
+		printf "%s - %s - %s - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "$1" "${VOLUMEID}" "$2" >> /var/log/flexrex.log
+	fi
 }
 
 # detect which binary is available: rexray-client or rexray
@@ -39,10 +54,6 @@ else
 	exit 1
 fi
 
-log() {
-	printf "%b" "$*" >&1
-}
-
 success() {
 	log '{"status": "Success"}'
 	exit 0
@@ -53,8 +64,13 @@ usage() {
 	err "\t$0 init\n"
 	err "\t$0 attach <json params>\n"
 	err "\t$0 detach <mount device>\n"
-	err "\t$0 mount <mount dir> <mount device> <json params>\n"
-	err "\t$0 unmount <mount dir>\n"
+	err "\t$0 mount <mount dir> <mount device> <json params> (1.5 only)\n"
+	err "\t$0 unmount <mount dir> (1.5 only)\n"
+	err "\t$0 waitforattach <mount device> <json params>"
+	err "\t$0 mountdevice <mount dir> <mount device> <json params>"
+	err "\t$0 unmountdevice <mount dir>"
+	err "\t$0 getvolumename <json params>"
+	err "\t$0 isattached <json params> <nodename>"
 	exit 1
 }
 
@@ -63,16 +79,68 @@ ismounted() {
 	if [ "${MOUNT}" = "${MNTPATH}" ]; then echo 1; else echo 0; fi
 }
 
+# Requires $JSON_PARAMS to be set
+# Sets $VOLUMEID
+volidfromjson() {
+	VOLUMEID=$(echo "${JSON_PARAMS}" | jq -r '.volumeID')
+	if [ -z "${VOLUMEID}" ] || [ "${VOLUMEID}" = null ]; then
+		err "{\"status\": \"Failure\", \"message\": \"Unable to extract volumeID\"}"
+		exit 1
+	fi
+}
+
+# Requires $VOLUMEID to be set
+# Sets $REX_OUTPUT
+getvolinfowithpath() {
+	REX_OUTPUT=$(${REXRAY_BIN} volume ls "${VOLUMEID}" --path --format json 2>/dev/null)
+}
+
+# Requires $VOLUMEID to be set
+# Sets $DEV
+getvolumedevice() {
+	# Make call to get device info
+	getvolinfowithpath
+	DEV=$(echo "${REX_OUTPUT}" | jq -r '.[0].attachments[0].deviceName')
+	if [ -z "$DEV" ]; then
+		debug "getvolumedevice" "failed to get device name - rexray_response: ${REX_OUTPUT}"
+		err "{\"status\": \"Failure\", \"message\": \"REX-Ray did not return attached device name\"}"
+		exit 1
+	fi
+	if [ ! -b "${DEV}" ]; then
+		err "{\"status\": \"Failure\", \"message\": \"Volume ${VOLUMEID} not present at ${DEV}\"}"
+		exit 1
+	fi
+}
+
+# Requires $VOLUMEID to be set
+# Sets $ATTACH_STATUS
+getattachstatus() {
+	ATTACH_STATUS=$(${REXRAY_BIN} volume ls "${VOLUMEID}" --format json 2>/dev/null | jq '.[0].attachmentState')
+	if [ "$FLEXREX_DEBUG" = "1" ]; then
+		case "$ATTACH_STATUS" in
+			1)
+				VOLUME_STATUS_NAME="unknown"
+				;;
+			2)
+				VOLUME_STATUS_NAME="attached"
+				;;
+			3)
+				VOLUME_STATUS_NAME="available"
+				;;
+			4)
+				VOLUME_STATUS_NAME="unavailable"
+				;;
+		esac
+		debug "getattachstatus" "volume status is ${VOLUME_STATUS_NAME}"
+	fi
+}
+
 attach() {
-	VOLUMEID=$(echo "$1" | jq -r '.volumeID')
+	JSON_PARAMS=$1
+	volidfromjson
 	FORCE_ATTACH=$(echo "$1" | jq -r '.forceAttach')
 	FORCE_ATTACH_DELAY=$(echo "$1" | jq -r '.forceAttachDelay')
 	VOLUME_AVAILABLE=0
-
-	if [ -z "$VOLUMEID" ]; then
-		err '{"status": "Failure", "message": "Unable to extract volumeID"}'
-		exit 1
-	fi
 
 	if [ "$FORCE_ATTACH" = "true" ]; then
 		if echo "$FORCE_ATTACH_DELAY" | grep '^-\{0,1\}[[:digit:]]\{1,\}$' > /dev/null; then
@@ -80,40 +148,17 @@ attach() {
 			COUNTER=0
 			COUNTER_LOGGED=1
 			while [ "$COUNTER" -lt "$STATUS_CHECKS" ]; do
-				VOLUME_STATUS=$(${REXRAY_BIN} volume ls "${VOLUMEID}" --format json 2>/dev/null | jq '.[0].attachmentState')
-				if [ "$FLEXREX_DEBUG" = "1" ]; then
-					case "$VOLUME_STATUS" in
-						1)
-							VOLUME_STATUS_NAME="unknown"
-							;;
-						2)
-							VOLUME_STATUS_NAME="attached"
-							;;
-						3)
-							VOLUME_STATUS_NAME="available"
-							;;
-						4)
-							VOLUME_STATUS_NAME="unavailable"
-							;;
-					esac
-					printf "%s - attach - %s - volume status is %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" "${VOLUME_STATUS_NAME}" >> /var/log/flexrex.log
-				fi
-				if [ "$VOLUME_STATUS" -eq "2" ]; then
-					if [ "$FLEXREX_DEBUG" = "1" ]; then
-						printf "%s - attach - %s - volume is already attached, skipping attachment\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" >> /var/log/flexrex.log
-					fi
+				getattachstatus
+				if [ "$ATTACH_STATUS" -eq "2" ]; then
+					debug "attach" "volume is already attached, skipping attachment"
 					VOLUME_ATTACHED=1
 					break;
-				elif [ "$VOLUME_STATUS" -eq "3" ]; then
-					if [ "$FLEXREX_DEBUG" = "1" ]; then
-						printf "%s - attach - %s - volume is available, breaking loop\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" >> /var/log/flexrex.log
-					fi
+				elif [ "$ATTACH_STATUS" -eq "3" ]; then
+					debug "attach" "volume is available, breaking loop"
 					VOLUME_AVAILABLE=1
 					break;
 				fi
-				if [ "$FLEXREX_DEBUG" = "1" ]; then
-					printf "%s - attach - %s - sleeping for 5 seconds after status check #%s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" "${COUNTER_LOGGED}" >> /var/log/flexrex.log
-				fi
+				debug "attach" "sleepign for 5 seconds after status check"
 				sleep 5
 				[ "$(( COUNTER=COUNTER+1 ))" -ne 0 ]
 				[ "$(( COUNTER_LOGGED=COUNTER_LOGGED+1 ))" -ne 0 ]
@@ -122,23 +167,15 @@ attach() {
 		if [ "$VOLUME_ATTACHED" = "1" ]; then
 			ATTACH_EXIT_CODE=0
 		elif [ "$VOLUME_AVAILABLE" = "1" ]; then
-			if [ "$FLEXREX_DEBUG" = "1" ]; then
-				printf "%s - attach - %s - attaching after volume available\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" >> /var/log/flexrex.log
-			fi
+			debug "attach" "attaching after volume available"
 			OUTPUT=$(${REXRAY_BIN} volume attach "${VOLUMEID}" -i --format json 2>/dev/null)
 			ATTACH_EXIT_CODE=$?
-			if [ "$FLEXREX_DEBUG" = "1" ]; then
-				printf "%s - attach - %s - rexray_attach_response: %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" "${OUTPUT}" >> /var/log/flexrex.log
-			fi
+			debug "attach" "rexray_attach_response ${OUTPUT}"
 		else
-			if [ "$FLEXREX_DEBUG" = "1" ]; then
-				printf "%s - attach - %s - forcing attach after timer expiration\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" >> /var/log/flexrex.log
-			fi
+			debug "attach" "forcing attach after timer expiration"
 			OUTPUT=$(${REXRAY_BIN} volume attach "${VOLUMEID}" -i --force --format json 2>/var/log/rexray.log)
 			ATTACH_EXIT_CODE=$?
-			if [ "$FLEXREX_DEBUG" = "1" ]; then
-				printf "%s - attach - %s - rexray_attach_response: %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" "${OUTPUT}" >> /var/log/flexrex.log
-			fi
+			debug "attach" "rexray_attach_response ${OUTPUT}"
 		fi
 
 	else
@@ -147,9 +184,7 @@ attach() {
 	fi
 
 	if [ "$ATTACH_EXIT_CODE" -ne "0" ]; then
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - attach - %s - nonzero exit code during attach: %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" "${ATTACH_EXIT_CODE}" >> /var/log/flexrex.log
-		fi
+		debug "attach" "nonzero exit code during attach: ${ATTACH_EXIT_CODE}"
 		err "{\"status\": \"Failure\", \"message\": \"REX-Ray returned error during attach\"}"
 		exit 1
 	fi
@@ -158,62 +193,88 @@ attach() {
 	sleep 2
 
 	# Make second call to get device info
-	OUTPUT=$(${REXRAY_BIN} volume ls "${VOLUMEID}" --path --format json 2>/dev/null)
-	DEV=$(echo "${OUTPUT}" | jq -r '.[0].attachments[0].deviceName')
-	if [ -z "$DEV" ]; then
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - attach - %s - failed to get device name - rexray_response: %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" "${OUTPUT}" >> /var/log/flexrex.log
-		fi
-		err '{"status": "Failure", "message": "REX-Ray did not return attached device name"}'
-		exit 1
-	fi
-	if [ ! -b "${DEV}" ]; then
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - attach - %s - volume not present at %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUMEID}" "${DEV}" >> /var/log/flexrex.log
-		fi
-		err "{\"status\": \"Failure\", \"message\": \"Volume ${VOLUMEID} not present at ${DEV}\"}"
-		exit 1
+	getvolumedevice
+	log "{\"status\": \"Success\", \"device\":\"${DEV}\"}"
+	exit 0
+}
+
+waitforattach() {
+	EXPECTED_DEV=$1
+	JSON_PARAMS=$2
+	volidfromjson
+	getvolumedevice
+	if [ ${EXPECTED_DEV} != ${DEV} ]; then
+		debug "waitforattach" "device at unexpected location. found: ${DEV}, expected: ${EXPECTED_DEV}"
+		err "{\"status\": \"Failure\", \"message\": \"REX-Ray returned error during attach\"}"
 	fi
 	log "{\"status\": \"Success\", \"device\":\"${DEV}\"}"
 	exit 0
 }
 
+isattached() {
+	JSON_PARAMS=$1
+	volidfromjson
+	getattachstatus
+	if [ "$ATTACH_STATUS" -eq "3" ]; then
+		log "{\"status\": \"Success\", \"attached\":True}"
+		exit 0
+	fi
+	err "{\"status\": \"Failure\", \"message\": \"Volume not attached\", \"attached\":False}"
+	exit 1
+}
+
+# Requires $VOLUMEID and $VOLUME_PATH to be set
 detach() {
+	if [ "${VOLUME_PATH}" = "" ]; then
+		debug "detach" "detaching volume"
+		${REXRAY_BIN} volume detach -i "${VOLUMEID}" >/dev/null 2>&1
+		DETACH_EXIT_CODE=$?
+		if [ "${DETACH_EXIT_CODE}" -ne "0" ]; then
+			err "{\"status\": \"Failure\", \"message\": \"REX-Ray returned error during detach\"}"
+			exit 1
+		fi
+	else
+		debug "detach" "volume is currently mounted to ${VOLUME_PATH}"
+		err "{\"status\": \"Failure\", \"message\": \"Volume ${VOLUMEID} is currently mounted at ${VOLUME_PATH}\"}"
+		exit 1
+	fi
+
+	log "{\"status\": \"Success\"}"
+	exit 0
+}
+
+detachvolume() {
+	VOLUMEID=$1
+	getattachstatus
+	if [ "$ATTACH_STATUS" -ne "2" ]; then
+		log "{\"status\": \"Success\"}"
+		exit 0
+	fi
+	getvolinfowithpath
+	VOLUME_PATH=$(echo "${REX_OUTPUT}" | jq -r '.path')
+
+	detach
+}
+
+detachdevice() {
 	DEV=$1
 	if [ ! -b "${DEV}" ]; then
 		err "{\"status\": \"Failure\", \"message\": \"Device ${DEV} does not exist\"}"
 		exit 1
 	fi
 
+	# When only given the device, we have to match on the attachment details from all volumes
 	VOLUMES=$(${REXRAY_BIN} volume ls --path --format json 2>/dev/null)
 	VOLUME_ATTACHMENT_DETAILS=$(${REXRAY_BIN} volume ls --path --format json | jq -r '[.[] | {name: .name, id: .id, device:.attachments[0].deviceName, path:.Path}] | .[] | select(.device == '\""${DEV}"\"')')
-	VOLUME_NAME=$(echo "${VOLUME_ATTACHMENT_DETAILS}" | jq -r '.name')
-	VOLUME_ID=$(echo "${VOLUME_ATTACHMENT_DETAILS}" | jq -r '.id')
+	VOLUMEID=$(echo "${VOLUME_ATTACHMENT_DETAILS}" | jq -r '.id')
 	VOLUME_PATH=$(echo "${VOLUME_ATTACHMENT_DETAILS}" | jq -r '.path')
 
-	if [ -z "$VOLUME_ID" ]; then
+	if [ -z "$VOLUMEID" ]; then
 		err "{\"status\": \"Failure\", \"message\": \"Could not find source volume for device ${DEV}\"}"
 		exit 1
 	fi
 
-	if [ "$VOLUME_PATH" = "" ]; then
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - detach - %s - detaching volume\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUME_NAME}" >> /var/log/flexrex.log
-		fi
-		${REXRAY_BIN} volume detach -i "${VOLUME_ID}" >/dev/null 2>&1
-		DETACH_EXIT_CODE=$?
-		if [ "$DETACH_EXIT_CODE" -ne "0" ]; then
-			err "{\"status\": \"Failure\", \"message\": \"REX-Ray returned error during detach\"}"
-			exit 1
-		fi
-	else
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - detach - %s - volume is currently mounted to %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${VOLUME_NAME}" "${VOLUME_PATH}" >> /var/log/flexrex.log
-		fi
-	fi
-
-	log "{\"status\": \"Success\"}"
-	exit 0
+	detach
 }
 
 domount() {
@@ -262,6 +323,20 @@ unmount() {
 	success
 }
 
+getvolumename() {
+	JSON_PARAMS=$1
+	volidfromjson
+
+	VOLUME_NAME=$(${REXRAY_BIN} volume ls "${VOLUMEID}" --format json 2>/dev/null | jq -r '.[0].id')
+	if [ -z "$VOLUME_NAME" ]; then
+		err "{\"status\": \"Failure\", \"message\": \"Could not get name of volume ${VOLUME_NAME} via REX-Ray. Does it exist?\"}"
+		exit 1
+	fi
+
+	log "{\"status\": \"Success\", \"volumeName\":\"${VOLUME_NAME}\"}"
+	exit 0
+}
+
 op=$1
 
 if [ "$op" = "init" ]; then success; fi
@@ -269,33 +344,53 @@ if [ "$#" -lt "2" ]; then usage; fi
 
 shift
 
+debug "$op" "$*"
+
 case "$op" in
 	attach)
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - attach - %b\n" "$(date +"%Y-%m-%d %H:%M:%S")" "$*" >> /var/log/flexrex.log
-		fi
 		attach "$@"
 		;;
 	detach)
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - detach -  %b\n" "$(date +"%Y-%m-%d %H:%M:%S")" "$*" >> /var/log/flexrex.log
+		if [ -e "$1" ]; then
+			detachdevice "$@"
+		else
+			detachvolume "$@"
 		fi
-		detach "$@"
 		;;
 	mount)
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - mount -  %b\n" "$(date +"%Y-%m-%d %H:%M:%S")" "$*" >> /var/log/flexrex.log
+		# 3 args is k8s 1.5 style
+		if [ "$#" -eq "3" ]; then
+			domount "$@"
 		fi
-		domount "$@"
+		# Defer to k8s default bind-mount since we support mountdevice
+		err "{\"status\": \"Not supported\"}"
 		;;
 	unmount)
-		if [ "$FLEXREX_DEBUG" = "1" ]; then
-			printf "%s - unmount -  %b\n" "$(date +"%Y-%m-%d %H:%M:%S")" "$*" >> /var/log/flexrex.log
+		# k8s 1.5 passes in a mount point here
+		if [ -e "$1" ]; then
+			unmount "$@"
 		fi
+		# Defer to k8s default bind-mount since we support unmountdevice
+		err "{\"status\": \"Not supported\"}"
+		;;
+	waitforattach)
+		waitforattach "$@"
+		;;
+	mountdevice)
+		domount "$@"
+		;;
+	unmountdevice)
 		unmount "$@"
 		;;
+	getvolumename)
+		getvolumename "$@"
+		;;
+	isattached)
+                isattached "$@"
+                ;;
 	*)
-		usage
+		err "{\"status\": \"Failure\", \"message\": \"Unsupported command\"}"
+		exit 1
 esac
 
 exit 1


### PR DESCRIPTION
This patch adds support for the k8s 1.6 FlexVolume changes. This is by
adding commands for: `waitforattach`, `mountdevice`, `unmountdevice`,
`getvolumename`, and `isattached`.

The debug logging is now handled more centrally.

Fixes #777 

This also Fixes #716, as a more meaningful error is displayed if the volume does not already exist.