### PR TITLE
Support for default TLS behavior in REX-Ray

### DIFF
--- a/cli/cli/cmds_00_other.go
+++ b/cli/cli/cmds_00_other.go
@@ -49,6 +49,7 @@ func (c *CLI) initOtherCmds() {
 		Short: "Install REX-Ray",
 		Run: func(cmd *cobra.Command, args []string) {
 			if installFunc != nil {
+				installSelfCert(c.ctx, c.config)
 				installFunc()
 			}
 		},

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f03101744b49400e3b7b98393f38557978019fab08cc0b3d9e2af979e56671bd
-updated: 2017-04-25T12:54:17.435453239-05:00
+hash: 0f25be1d7ce40caf47d76958c73911ddfa80d2eaa0c3a483c6e70cad935b50b4
+updated: 2017-05-01T21:12:23.260913325-04:00
 imports:
 - name: cloud.google.com/go
   version: e4de3dc4493f142c5833f3185e1182025a61f805
@@ -98,7 +98,7 @@ imports:
   subpackages:
   - logrus
 - name: github.com/codedellemc/libstorage
-  version: e752e4ca6ae3a8314c07b4a40d354cfce95c48bf
+  version: 58c5f05c978076ecc41de30ed631f3bb5e6af06d
   repo: https://github.com/codedellemc/libstorage
   subpackages:
   - api
@@ -272,7 +272,8 @@ imports:
 - name: github.com/tent/http-link-go
   version: ac974c61c2f990f4115b119354b5e0b47550e888
 - name: golang.org/x/crypto
-  version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
+  version: 453249f01cfeb54c3d549ddb75ff152ca243f9d8
+  repo: https://github.com/golang/crypto.git
   subpackages:
   - curve25519
   - ed25519
@@ -304,7 +305,8 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: a8b38433e35b65ba247bb267317037dee1b70cea
+  version: 85c29909967d7f171f821e7a42e7b7af76fb9598
+  repo: https://github.com/golang/text.git
   subpackages:
   - transform
   - unicode/norm

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: e752e4ca6ae3a8314c07b4a40d354cfce95c48bf # libstorage-version
+    version: 58c5f05c978076ecc41de30ed631f3bb5e6af06d # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig

--- a/util/util_tls.go
+++ b/util/util_tls.go
@@ -1,0 +1,203 @@
+package util
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/akutz/gotil"
+	apitypes "github.com/codedellemc/libstorage/api/types"
+)
+
+var (
+	orgName       = "libstorage"
+	certBlockType = "CERTIFICATE"
+	keyBlockType  = "RSA PRIVATE KEY"
+)
+
+// CreateSelfCert creates self-signed certificate and a private key
+func CreateSelfCert(ctx apitypes.Context, certPath, keyPath, host string) error {
+
+	// if files exist, ignore
+	_, cerErr := os.Stat(certPath)
+	_, keyErr := os.Stat(keyPath)
+	if cerErr == nil && keyErr == nil {
+		ctx.WithFields(log.Fields{
+			"host":     host,
+			"certPath": certPath,
+			"certKey":  certPath,
+		}).Debug("skipping self-cert creation, files exist")
+		return nil
+	}
+
+	certRoot := filepath.Dir(certPath)
+	keyRoot := filepath.Dir(keyPath)
+	if err := os.MkdirAll(certRoot, 0755); err != nil {
+		ctx.WithFields(log.Fields{
+			"host":     host,
+			"certRoot": certRoot,
+		}).Debug("created dir")
+
+		return err
+	}
+	if keyRoot != certRoot {
+		if err := os.MkdirAll(keyRoot, 0755); err != nil {
+			ctx.WithFields(log.Fields{
+				"host":    host,
+				"keyRoot": keyRoot,
+			}).Debug("created dir")
+			return err
+		}
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return err
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: serialNumber,
+
+		Subject: pkix.Name{
+			Organization: []string{orgName},
+			CommonName:   host,
+		},
+
+		IPAddresses: []net.IP{net.ParseIP(host)},
+		DNSNames:    []string{"localhost"},
+
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().AddDate(1, 0, 0),
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		KeyUsage: x509.KeyUsageKeyEncipherment |
+			x509.KeyUsageDigitalSignature,
+
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	// gen cert file
+	ctx.WithField("certFile", certPath).Debug("creating cert file")
+	certBlock, err := x509.CreateCertificate(
+		rand.Reader,
+		&tmpl,
+		&tmpl,
+		&privKey.PublicKey,
+		privKey)
+	if err != nil {
+		return err
+	}
+
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		return err
+	}
+	defer certFile.Close()
+	if err := pem.Encode(
+		certFile,
+		&pem.Block{Type: certBlockType, Bytes: certBlock}); err != nil {
+		return err
+	}
+
+	// gen key file
+	ctx.WithField("keyFile", keyPath).Debug("creating key file")
+	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer keyFile.Close()
+
+	keyBlock := x509.MarshalPKCS1PrivateKey(privKey)
+	if err != nil {
+		return err
+	}
+
+	if err := pem.Encode(
+		keyFile,
+		&pem.Block{Type: keyBlockType, Bytes: keyBlock}); err != nil {
+		return err
+	}
+
+	ctx.WithFields(log.Fields{
+		"certPath": certPath,
+		"certKey":  certPath,
+	}).Debug("self-cert files created")
+
+	return nil
+}
+
+// AssertTrustedHost presents user with prompt to accept/reject host as trusted
+func AssertTrustedHost(
+	ctx apitypes.Context,
+	host,
+	algo string,
+	fingerprint []byte,
+) bool {
+	trusted := "no"
+	fmt.Printf("\nRejecting connection to unknown host %s.\n", host)
+	fmt.Printf("SHA Fingerprint presented: %s:%x/%x.\n",
+		algo, fingerprint[0:8], fingerprint[len(fingerprint)-2:])
+	fmt.Print("Do you want to save host to known_hosts file? (yes/no): ")
+	fmt.Scanf("%s", &trusted)
+	if strings.EqualFold(trusted, "yes") {
+		return true
+	}
+	return false
+}
+
+// AddKnownHost adds unknown host to know_hosts file
+func AddKnownHost(
+	ctx apitypes.Context,
+	knownHostPath,
+	host, algo string,
+	fingerprint []byte) error {
+
+	knownHostPathDir := filepath.Dir(knownHostPath)
+
+	if !gotil.FileExists(knownHostPathDir) {
+		if err := os.MkdirAll(knownHostPathDir, 0755); err != nil {
+			return err
+		}
+		ctx.WithField("dir", knownHostPathDir).
+			Debug("created directory for known_hosts")
+	}
+
+	khFile, err := os.OpenFile(
+		knownHostPath, os.O_WRONLY|
+			os.O_CREATE|
+			os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	defer khFile.Close()
+
+	fmt.Fprintf(khFile, "%s %s %x\n", host, algo, fingerprint)
+	if host == "127.0.0.1" {
+		fmt.Fprintf(khFile, "%s %s %x\n", "localhost", algo, fingerprint)
+	}
+
+	ctx.WithFields(log.Fields{
+		"host":        host,
+		"algo":        algo,
+		"fingerprint": fmt.Sprintf("%x", fingerprint),
+	}).Debug("fingerprint added to known_hosts file")
+
+	return nil
+}

--- a/util/util_tls_test.go
+++ b/util/util_tls_test.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"crypto/tls"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/akutz/gotil"
+	"github.com/codedellemc/libstorage/api/context"
+)
+
+func TestCreateSelfCert(t *testing.T) {
+	certPath := "/tmp/libstorage/tls/file.crt"
+	keyPath := "/tmp/libstorage/tls/file.key"
+	host := "127.0.0.1"
+
+	err := CreateSelfCert(context.Background(), certPath, keyPath, host)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		os.Remove(certPath)
+		os.Remove(keyPath)
+	}()
+
+	tlsKeypair, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("failed to create TLS keypair: %v", err)
+	}
+
+	s := httptest.NewUnstartedServer(http.HandlerFunc(
+		func(resp http.ResponseWriter, req *http.Request) {
+			resp.WriteHeader(200)
+		},
+	))
+	defer s.Close()
+
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{tlsKeypair},
+	}
+	s.StartTLS()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	if _, err := client.Get(s.URL); err != nil {
+		log.Println(err)
+	}
+
+}
+
+func TestAddKnownHost(t *testing.T) {
+	knownHostPath := "/tmp/libstorage/tls/known_hosts"
+	algo := "sha256"
+	host := "localhost"
+	fingerprint := []byte("4bd46851a059aab36255863c8d679b6")
+
+	err := AddKnownHost(
+		context.Background(),
+		knownHostPath,
+		host, algo,
+		fingerprint)
+	defer os.Remove(knownHostPath)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !gotil.FileExists(knownHostPath) {
+		t.Fatal("knwon_hosts file not getting created")
+	}
+}


### PR DESCRIPTION
This commit adds support for detault TLS communication between REX-Ray client and controller:
- Auto creates keypair files of certificate and key
- Interacts with user to confirm host acceptance
- Creates know_hosts files to store host fingerprint