### PR TITLE
Self-signed cert fixes

### DIFF
--- a/cli/cli/installer_std_controller.go
+++ b/cli/cli/installer_std_controller.go
@@ -23,7 +23,7 @@ func installSelfCert(ctx apitypes.Context, config gofig.Config) {
 
 	fmt.Println("Generating server self-signed certificate...")
 	if err := util.CreateSelfCert(ctx, certPath, keyPath, host); err != nil {
-		ctx.Fatalf("cert generation failed: %v\n", err)
+		ctx.WithError(err).Fatal("cert generation failed")
 	}
 
 	fmt.Printf("Created cert file %s, key %s\n\n", certPath, keyPath)

--- a/cli/cli/installer_std_controller.go
+++ b/cli/cli/installer_std_controller.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	log "github.com/Sirupsen/logrus"
 	gofig "github.com/akutz/gofig/types"
@@ -15,7 +16,11 @@ import (
 func installSelfCert(ctx apitypes.Context, config gofig.Config) {
 	certPath := config.GetString(apitypes.ConfigTLSCertFile)
 	keyPath := config.GetString(apitypes.ConfigTLSKeyFile)
-	host := "127.0.0.1"
+
+	host, err := os.Hostname()
+	if err != nil {
+		log.Fatalf("failed to get hostname for cert")
+	}
 
 	fmt.Println("Generating server self-signed certificate...")
 	if err := util.CreateSelfCert(ctx, certPath, keyPath, host); err != nil {

--- a/cli/cli/installer_std_controller.go
+++ b/cli/cli/installer_std_controller.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	gofig "github.com/akutz/gofig/types"
 	apitypes "github.com/codedellemc/libstorage/api/types"
 	"github.com/codedellemc/rexray/util"
@@ -19,12 +18,12 @@ func installSelfCert(ctx apitypes.Context, config gofig.Config) {
 
 	host, err := os.Hostname()
 	if err != nil {
-		log.Fatalf("failed to get hostname for cert")
+		ctx.Fatalf("failed to get hostname for cert")
 	}
 
 	fmt.Println("Generating server self-signed certificate...")
 	if err := util.CreateSelfCert(ctx, certPath, keyPath, host); err != nil {
-		log.Fatalf("cert generation failed: %v\n", err)
+		ctx.Fatalf("cert generation failed: %v\n", err)
 	}
 
 	fmt.Printf("Created cert file %s, key %s\n\n", certPath, keyPath)

--- a/util/util_tls.go
+++ b/util/util_tls.go
@@ -95,9 +95,9 @@ func CreateSelfCert(
 	} else {
 		ips, err := net.LookupIP(host)
 		if err != nil {
-			ctx.WithFields(log.Fields{
+			ctx.WithError(err).WithFields(log.Fields{
 				"host": host,
-			}).Debug("failed to lookup IP for host: ", err)
+			}).Debug("failed IP lookup for host")
 		} else {
 			tmpl.IPAddresses = append(tmpl.IPAddresses, ips...)
 		}


### PR DESCRIPTION
Correctly fill in CN = hostname
Setup Subject Alternate Names IP and DNS
Set CA field to true
Update test to verify cert

Cert validation result

```
> sudo openssl verify -CAfile /etc/libstorage/tls/libstorage.crt /etc/libstorage/tls/libstorage.crt
/etc/libstorage/tls/libstorage.crt: OK
```

Cert output
```
> sudo openssl x509 -in /etc/libstorage/tls/libstorage.crt -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            e4:9f:8a:05:b0:4a:e2:6e:83:c7:09:9f:14:db:e7:f0
    Signature Algorithm: sha256WithRSAEncryption
        Issuer: O=libstorage, CN=ubuntu
        Validity
            Not Before: May  3 04:31:03 2017 GMT
            Not After : May  3 04:31:03 2018 GMT
        Subject: O=libstorage, CN=ubuntu
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:bd:64:d6:25:d1:ca:07:3e:ae:59:c8:f8:3c:03:
                    5c:85:cc:ad:3a:87:9c:f9:79:a9:b5:ba:b6:d2:e1:
                    91:ff:84:5d:1b:28:6d:06:6b:03:a7:d0:62:fa:57:
                    d0:3b:c4:6e:09:4d:e0:d2:d2:d0:db:5a:46:bc:4e:
                    98:a1:2a:b5:be:9b:08:42:52:35:35:fb:00:99:50:
                    4a:30:95:c0:f1:33:69:cd:d4:6b:57:4c:8a:2c:17:
                    f7:9a:6d:9a:08:ba:bc:d2:b3:4e:2d:9f:d7:82:b1:
                    94:e8:f8:a6:15:fa:b6:66:db:97:87:a4:cf:a0:90:
                    02:bd:0e:52:ee:f9:28:9e:15:58:67:e0:54:dc:fc:
                    06:10:39:d1:d6:b3:ff:29:90:d9:06:dd:89:4b:9a:
                    d4:9c:1a:e6:fb:8a:fc:d0:9f:d0:f8:71:e0:2d:12:
                    4c:53:bd:06:f5:8c:13:1c:0b:3f:29:d2:73:ec:76:
                    65:57:2a:c5:39:42:3a:b3:fe:c7:46:ac:78:f7:34:
                    79:54:2f:12:86:99:3d:ed:53:56:e5:96:18:ff:5b:
                    32:42:93:78:02:d9:9d:4a:1e:fa:57:ed:dc:dd:be:
                    6f:46:2f:a7:4d:31:c6:82:f5:af:4d:ff:20:5c:b5:
                    64:a6:05:8b:c7:0f:e2:6d:96:0d:b2:9d:6d:62:9e:
                    9a:49
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment, Certificate Sign
            X509v3 Extended Key Usage:
                TLS Web Server Authentication
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Alternative Name:
                DNS:ubuntu, IP Address:127.0.1.1
    Signature Algorithm: sha256WithRSAEncryption
         25:46:15:f2:f9:50:14:8f:48:7c:ed:4a:f0:69:49:aa:c6:c2:
         22:68:61:8a:de:bb:13:7b:4a:ca:3e:14:1b:c8:3d:10:08:2e:
         1a:9f:0a:9c:4b:1a:c0:f2:cb:d4:12:1a:3b:4d:e6:36:c4:5c:
         10:50:0f:fa:45:82:16:c9:b1:44:df:f2:b2:df:44:fc:96:6f:
         14:67:c7:69:55:ca:63:b6:f9:bd:04:53:ca:f5:38:f0:2d:2d:
         13:ea:87:a5:b9:c1:a2:13:f6:2c:f7:51:98:57:15:76:48:d8:
         2d:88:55:ad:b2:d3:7e:81:c8:bc:74:00:62:a5:6f:41:1d:79:
         f2:8a:c9:e6:ee:cd:22:14:ce:02:32:60:e1:21:fe:7d:80:d2:
         c5:94:e0:d5:8c:7e:7d:8a:25:85:fd:6b:a4:1c:3b:ca:07:3e:
         73:b2:1c:1f:c5:99:f2:f1:94:2b:cb:b6:ef:d0:3f:02:36:1a:
         6c:6c:6b:14:0b:85:4c:73:05:6e:c9:31:81:4b:b9:dc:e3:b4:
         d7:2f:26:6c:07:46:74:dc:56:ee:21:12:7f:d7:ac:98:11:f0:
         90:3f:fe:f4:09:11:a0:13:16:17:df:fd:e2:8e:75:af:2f:f7:
         2f:df:07:4a:6e:c8:8f:7e:16:a8:39:e1:1c:42:8f:7d:6b:40:
         b6:0d:f8:fa
```