### PR TITLE
Build Support for arm/arm64

### DIFF
--- a/.Dockerfile
+++ b/.Dockerfile
@@ -10,7 +10,6 @@ WORKDIR @WORKDIR_RR@
 
 WORKDIR @WORKDIR_RR@
 RUN @BUILD_CMD@
-RUN /go/bin/$REXRAY version
 
 FROM alpine:3.5
 
@@ -18,7 +17,7 @@ LABEL build="@BUILD_TYPE@"
 LABEL drivers="@DRIVERS@"
 LABEL version="@SEMVER@"
 
-COPY --from=rexray@FNAME_SUFFIX@-builder /go/bin/$REXRAY /usr/bin/$REXRAY
+COPY --from=rexray@FNAME_SUFFIX@-builder /go/bin/@GOOS_GOARCH_DIR@$REXRAY /usr/bin/$REXRAY
 COPY @DOCKERFILE@ /Dockerfile
 
 RUN apk update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ go:
   - 1.8.1
 
 env:
-  - REXRAY_BUILD_TYPE=
+  - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=amd64
+  - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=arm
+  - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=arm64
   - REXRAY_BUILD_TYPE=client
   - REXRAY_BUILD_TYPE=agent
   - REXRAY_BUILD_TYPE=controller
@@ -23,6 +25,8 @@ env:
   - REXRAY_BUILD_TYPE= DRIVERS=scaleio
 
 before_install:
+  - export GOARCH="${TRAVIS_GOARCH:-amd64}"
+  - go env
   - if [ "$DRIVERS" != "" ]; then sudo apt-get update; fi
   - if [ "$DRIVERS" != "" ]; then sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine; fi
   - if [ "$DRIVERS" != "" ]; then docker --version; fi
@@ -39,20 +43,19 @@ before_install:
 
 script:
   - make gometalinter-all
-#  - make -j build-libstorage
-#  - GOOS=linux GOARCH=amd64 make -j build
-  - ./build.sh -x -b make
-  - if [ "$REXRAY_BUILD_TYPE" = "" ]; then REXRAY_DEBUG=true $GOPATH/bin/rexray version; else REXRAY_DEBUG=true $GOPATH/bin/rexray-$REXRAY_BUILD_TYPE version; fi
-  - make -j test
+  - ./build.sh -x -a "$GOARCH" -b make
+  - if [ "$REXRAY_BUILD_TYPE" = "" ]; then file rexray; else REXRAY_DEBUG=true file rexray-$REXRAY_BUILD_TYPE; fi
+  - if [ "$GOARCH" = "amd64" ]; then if [ "$REXRAY_BUILD_TYPE" = "" ]; then REXRAY_DEBUG=true ./rexray version; else REXRAY_DEBUG=true ./rexray-$REXRAY_BUILD_TYPE version; fi; fi
+  - if [ "$GOARCH" = "amd64" ]; then make -j test; fi
 
 after_success:
-  - if [ "$DRIVERS" = "" ]; then make -j cover; fi
-  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make tgz; fi
-  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make rpm; fi
-  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make deb; fi
-  - if [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make bintray; fi
-  - if [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make build-docker-plugin; fi
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then docker login -u $DOCKER_USER -p $DOCKER_PASS; fi
+  - if [ "$GOARCH" = "amd64" ] && [ "$DRIVERS" = "" ]; then make -j cover; fi
+  - if [ "$GOARCH" = "amd64" ] && [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make tgz; fi
+  - if [ "$GOARCH" = "amd64" ] && [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make rpm; fi
+  - if [ "$GOARCH" = "amd64" ] && [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make deb; fi
+  - if [ "$GOARCH" = "amd64" ] && [ "$DRIVERS" = "" ]  && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make bintray; fi
+  - if [ "$GOARCH" = "amd64" ] && [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then make build-docker-plugin; fi
+  - if [ "$GOARCH" = "amd64" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$REXRAY_BUILD_TYPE" = "" ] && [ "$DRIVERS" != "" ] && [ "$TRAVIS_OS_NAME" = "$BINTRAY_OS_NAME" ]; then docker login -u $DOCKER_USER -p $DOCKER_PASS; fi
   - ls -al
 
 deploy:
@@ -63,7 +66,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $DRIVERS = '' && $DISABLE_BINTRAY != true && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
+      condition: $GOARCH = 'amd64' && $DRIVERS = '' && $DISABLE_BINTRAY != true && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
 
   - provider: bintray
     file: bintray-staged.json
@@ -72,7 +75,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $DRIVERS = '' && $DISABLE_BINTRAY != true && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $GOARCH = 'amd64' && $DRIVERS = '' && $DISABLE_BINTRAY != true && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
   - provider: bintray
     file: bintray-stable.json
@@ -81,28 +84,28 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $DRIVERS = '' && $DISABLE_BINTRAY != true && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $GOARCH = 'amd64' && $DRIVERS = '' && $DISABLE_BINTRAY != true && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
   - provider: script
     script: ./make.sh push-docker-plugin unstable
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
+      condition: $GOARCH = 'amd64' && $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
 
   - provider: script
     script: ./make.sh push-docker-plugin staged
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $GOARCH = 'amd64' && $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
   - provider: script
     script: ./make.sh push-docker-plugin stable
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $GOARCH = 'amd64' && $DRIVERS != '' && $REXRAY_BUILD_TYPE = '' && $TRAVIS_OS_NAME = $BINTRAY_OS_NAME && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
 cache:
   apt: true

--- a/glide-docker.yaml
+++ b/glide-docker.yaml
@@ -15,7 +15,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: v0.6.0 # libstorage-version
+    version: 162d6b97a39c9248bdb89d4a52b1669af1f18c9a # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6938df327caad72d24274cdbf9fa3750acac04df8ef79712b46d276654eac901
-updated: 2017-05-03T16:17:11.584802513-05:00
+hash: 398a7d1e27434a05f2e06e8e90d9d9676fc70635ac2c369fc256116e08957f65
+updated: 2017-05-20T00:12:55.070473849-05:00
 imports:
 - name: cloud.google.com/go
   version: e4de3dc4493f142c5833f3185e1182025a61f805
@@ -98,7 +98,7 @@ imports:
   subpackages:
   - logrus
 - name: github.com/codedellemc/libstorage
-  version: fa055d6da595602715bdfd5541b4aa6d4dcbcbd9
+  version: 162d6b97a39c9248bdb89d4a52b1669af1f18c9a
   repo: https://github.com/codedellemc/libstorage
   subpackages:
   - api
@@ -174,7 +174,6 @@ imports:
   - drivers/storage/vbox/executor
   - drivers/storage/vbox/storage
   - drivers/storage/vfs
-  - drivers/storage/vfs/client
   - drivers/storage/vfs/executor
   - drivers/storage/vfs/storage
   - imports/config
@@ -243,7 +242,7 @@ imports:
   version: 1dd44b25b79c4d9060e582e90798e4d72537818c
   repo: https://github.com/akutz/go-bindata
 - name: github.com/kardianos/osext
-  version: 9d302b58e975387d0b4d9be876622c86cefe64be
+  version: ae77be60afb1dcacde03767a8c37337fad28ac14
   repo: https://github.com/kardianos/osext.git
   vcs: git
 - name: github.com/kr/fs

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,7 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: v0.6.0 # libstorage-version
+    version: 162d6b97a39c9248bdb89d4a52b1669af1f18c9a # libstorage-version
     repo:    https://github.com/codedellemc/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig


### PR DESCRIPTION
This patch, which fixes #860 and requires codedellemc/libstorage#553, updates the `Makefile` to support building REX-Ray for the arm and arm64 architectures. Additionally, this patch enhances the `build.sh` command with two, new flags:

Flag | Description
-----|------------
`-a` | Optional. Sets the `GOARCH` environment variable. Defaults to `amd64`. If the specified architecture is not `amd64` then the `-3` flag is set, removing the Docker image upon the completing the build. This is because there is no point in keeping the Docker image with an incompatible REX-Ray binary.
`-e` | Optional. A quoted, space delimited list of the `GOOS_GOARCH` executors to embed. The default value is `GOOS_GOARCH`.

### Build REX-Ray `arm64` (64-bit) Binary w `arm64` Executor ([gist](https://gist.github.com/akutz/78060fe9fe685b5f1c300bc355c000d0#file-build-arm64-sh))
```bash
$ ./build.sh -a arm64
```

### Verify the REX-Ray Binary is `arm64`
```bash
$ file rexray
rexray: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
```

### Build REX-Ray `arm` Binary w `amd64`, `arm`, and `arm64` Executors ([gist](https://gist.github.com/akutz/78060fe9fe685b5f1c300bc355c000d0#file-build-rexray-arm-multi-executors-sh))
**Note**: In the gist the `-s` indicates the use of the local libStorage sources as they include the necessary codedellemc/libstorage#553.
```bash
$ ./build.sh -a arm -e `linux_amd64 linux_arm linux_arm64`
```

### Verify the REX-Ray Binary is `arm` (32-bit)
```bash
$ file rexray
rexray: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, not stripped
```

cc/ @naster01