### PR TITLE
Go 1.8 Plug-in Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gopath.tgz*
 /rexray-*
 .glide.yaml.tmp
 .ls.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 go_import_path: github.com/codedellemc/rexray
 
-sudo: required
+#sudo: required
 
-services:
-  - docker
+#services:
+#  - docker
 
 language: go
 
@@ -12,17 +12,17 @@ go:
 
 env:
   - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=amd64
-  - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=arm
-  - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=arm64
-  - REXRAY_BUILD_TYPE=client
-  - REXRAY_BUILD_TYPE=agent
-  - REXRAY_BUILD_TYPE=controller
-  - REXRAY_BUILD_TYPE= DRIVERS=ebs
-  - REXRAY_BUILD_TYPE= DRIVERS=efs
-  - REXRAY_BUILD_TYPE= DRIVERS=gcepd
-  - REXRAY_BUILD_TYPE= DRIVERS=isilon
-  - REXRAY_BUILD_TYPE= DRIVERS=s3fs
-  - REXRAY_BUILD_TYPE= DRIVERS=scaleio
+#  - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=arm
+#  - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=arm64
+#  - REXRAY_BUILD_TYPE=client
+#  - REXRAY_BUILD_TYPE=agent
+#  - REXRAY_BUILD_TYPE=controller
+#  - REXRAY_BUILD_TYPE= DRIVERS=ebs
+#  - REXRAY_BUILD_TYPE= DRIVERS=efs
+#  - REXRAY_BUILD_TYPE= DRIVERS=gcepd
+#  - REXRAY_BUILD_TYPE= DRIVERS=isilon
+#  - REXRAY_BUILD_TYPE= DRIVERS=s3fs
+#  - REXRAY_BUILD_TYPE= DRIVERS=scaleio
 
 before_install:
   - export GOARCH="${TRAVIS_GOARCH:-amd64}"
@@ -39,6 +39,17 @@ before_install:
   - if [ "$DRIVERS" = "" ]; then go get github.com/onsi/ginkgo; fi
   - if [ "$DRIVERS" = "" ]; then go get golang.org/x/tools/cmd/cover; fi
   - make deps
+  - PORCELAIN=1 make build-gopath-tarball && ls -al gopath*
+  - export PROJECT_NAME="rexray"
+  - export GOPATH_OLD="$GOPATH"
+  - export GOPATH="/tmp/go"
+  - mkdir -p "$GOPATH"/{bin,pkg,src}
+  - mv "$GOPATH_OLD"/bin/* "$GOPATH"/bin/
+  - export PATH="${GOPATH}/bin:${PATH}"
+  - mkdir -p "$GOPATH"/src/github.com/codedellemc
+  - rsync -ax vendor/ "$GOPATH"/src/ && rm -fr vendor
+  - cd .. && mv "$PROJECT_NAME" "$GOPATH"/src/github.com/codedellemc/
+  - cd "$GOPATH"/src/github.com/codedellemc/"$PROJECT_NAME"
   - make info
 
 script:

--- a/cli/rexray/rexray.go
+++ b/cli/rexray/rexray.go
@@ -13,6 +13,7 @@ import (
 	"github.com/akutz/gotil"
 
 	"github.com/codedellemc/libstorage/api/context"
+	apimods "github.com/codedellemc/libstorage/api/mods"
 	"github.com/codedellemc/libstorage/api/registry"
 	apitypes "github.com/codedellemc/libstorage/api/types"
 	"github.com/codedellemc/libstorage/api/utils"
@@ -45,6 +46,9 @@ func Run() {
 	registry.ProcessRegisteredConfigs(ctx)
 
 	createUserKnownHostsFile(ctx, pathConfig)
+
+	// load shared objects
+	apimods.LoadModules(ctx, pathConfig)
 
 	onExit := func() {
 		if traceProfile != nil {

--- a/fbf.sh
+++ b/fbf.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+path="${1:-.}"
+size="${2:-1}"
+unit="${3:-M}" # ckMGTP
+if [ "$unit" = "b" ]; then unit="c"; fi
+
+find_big_files() {
+  find "$path" \
+    -not -path '*/.docker/*' \
+    -not -path '*/.docs/*' \
+    -not -path '*/.git/*' \
+    -not -path '*/.site/*' \
+    -not -path '*/vendor/*' \
+    -type f \
+    -size +"${size}${unit}" 2> /dev/null
+}
+
+print_big_files() {
+  if [ "$#" -eq 0 ]; then return 1; fi
+  $(env which ls) -lhS $* | \
+  awk '{ sub("'"$path"'\/?","",$9); print $5 "\t" $9 }' 2> /dev/null
+}
+
+print_big_files $(find_big_files)

--- a/glide-docker.yaml
+++ b/glide-docker.yaml
@@ -15,8 +15,8 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: b79ec99a9a3d72b4a55811a99dd591de58e27908 # libstorage-version
-    repo:    https://github.com/codedellemc/libstorage # libstorage-repo
+    version: d965df8d6e1e7ed1d1ab5a9f8cd0917786586e8a # libstorage-version
+    repo:    https://github.com/akutz/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig
     version: v0.1.6

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dc765574c68a28898be016332c918906be17220f7eb6715256ad137253375c21
-updated: 2017-05-22T15:49:10.599225841-05:00
+hash: c51fb40302158961bfdaade8ebe6c1590557a437dd6e0383bf3bda8ca6a20211
+updated: 2017-05-25T11:44:45.886424154-05:00
 imports:
 - name: cloud.google.com/go
   version: e4de3dc4493f142c5833f3185e1182025a61f805
@@ -98,12 +98,13 @@ imports:
   subpackages:
   - logrus
 - name: github.com/codedellemc/libstorage
-  version: b79ec99a9a3d72b4a55811a99dd591de58e27908
-  repo: https://github.com/codedellemc/libstorage
+  version: d965df8d6e1e7ed1d1ab5a9f8cd0917786586e8a
+  repo: https://github.com/akutz/libstorage
   subpackages:
   - api
   - api/client
   - api/context
+  - api/mods
   - api/registry
   - api/server
   - api/server/auth

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,8 +15,8 @@ import:
     repo:    https://github.com/akutz/logrus
 
   - package: github.com/codedellemc/libstorage
-    version: b79ec99a9a3d72b4a55811a99dd591de58e27908 # libstorage-version
-    repo:    https://github.com/codedellemc/libstorage # libstorage-repo
+    version: d965df8d6e1e7ed1d1ab5a9f8cd0917786586e8a # libstorage-version
+    repo:    https://github.com/akutz/libstorage # libstorage-repo
 
   - package: github.com/akutz/gofig
     version: v0.1.6


### PR DESCRIPTION
This patch introduces support for loading Linux shared object (.so) files as Go 1.8 plug-ins. This feature requires Linux.