### PR TITLE
Module-Scoped Host Definitions

### DIFF
--- a/daemon/module/module.go
+++ b/daemon/module/module.go
@@ -144,9 +144,16 @@ func InitializeDefaultModules(
 	// enable path caching for the modules
 	config.Set(apitypes.ConfigIgVolOpsPathCacheEnabled, true)
 
+	// attempt to activate libStorage. if an ErrHostDetectionFailed
+	// error occurs then just log it as a warning since modules may
+	// define hosts directly
 	ctx, config, errs, err = util.ActivateLibStorage(ctx, config)
 	if err != nil {
-		return nil, err
+		if err.Error() == util.ErrHostDetectionFailed.Error() {
+			ctx.Warn(err)
+		} else {
+			return nil, err
+		}
 	}
 
 	modConfigs, err := getConfiguredModules(ctx, config)

--- a/util/util_client_agent.go
+++ b/util/util_client_agent.go
@@ -3,8 +3,6 @@
 package util
 
 import (
-	"errors"
-
 	gofig "github.com/akutz/gofig/types"
 
 	apitypes "github.com/codedellemc/libstorage/api/types"
@@ -24,7 +22,7 @@ func activateLibStorage(
 		}
 	}
 	if host == "" && !isRunning {
-		return ctx, config, nil, errors.New("libStorage host config missing")
+		return ctx, config, nil, ErrHostDetectionFailed
 	}
 	return ctx, config, nil, nil
 }


### PR DESCRIPTION
This patch fixes #827 where a libStorage host may not be defined at the root of a configuration but instead scoped to a module. With this patch if host detection fails (root configuration / running, local host) when initializing the module subsystem a warning is logged and the modules themselves must explicitly define the host to which to connect.

This patch does *not* support starting a new host from a module-scoped host definition. The module-scoped host properties are for overriding the host to which to connect only.