### PR TITLE
Fix Required Permissions for S3FS Docker Plug-In

### DIFF
--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -66,6 +66,19 @@
           "docker.volumedriver/1.0"
         ]
       },
+      "Linux": {
+        "AllowAllDevices": true,
+        "Capabilities": ["CAP_SYS_ADMIN"],
+        "Devices": null
+      },
+      "Mounts": [
+        {
+          "Source": "/dev",
+          "Destination": "/dev",
+          "Type": "bind",
+          "Options": ["rbind"]
+        }
+      ], 
       "Network": {
         "Type": "host"
       },


### PR DESCRIPTION
This patch fixes the required plug-in permissions for the S3FS Docker Plug-in