### PR TITLE
CLI Freeform Options

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -102,6 +102,7 @@ type CLI struct {
 	flexRexUninstallCmd *cobra.Command
 	flexRexStatusCmd    *cobra.Command
 
+	options                 []string
 	verify                  bool
 	key                     string
 	alg                     string

--- a/cli/cli/cmds_00_other.go
+++ b/cli/cli/cmds_00_other.go
@@ -86,4 +86,8 @@ func (c *CLI) initOtherFlags() {
 
 	c.uninstallCmd.Flags().Bool("package", false,
 		"A flag indicating a package manager is performing the uninstallation")
+
+	c.c.PersistentFlags().StringSliceVarP(
+		&c.options, "options", "o", []string{},
+		"Specify one or more freeform options to pass to the API")
 }

--- a/cli/cli/cmds_10_volume.go
+++ b/cli/cli/cmds_10_volume.go
@@ -23,6 +23,18 @@ func init() {
 	})
 }
 
+func (c *CLI) addOpts(s apitypes.Store) {
+	for _, o := range c.options {
+		op := strings.SplitN(o, "=", 2)
+		switch len(op) {
+		case 1:
+			s.Set(op[0], true)
+		case 2:
+			s.Set(op[0], op[1])
+		}
+	}
+}
+
 func (c *CLI) initVolumeCmds() {
 
 	c.volumeCmd = &cobra.Command{
@@ -112,6 +124,9 @@ func (c *CLI) initVolumeCmds() {
 					Opts:             store(),
 				}
 			)
+
+			// add the freeform options
+			c.addOpts(opts.Opts)
 
 			if c.encryptionKey != "" {
 				opts.EncryptionKey = &c.encryptionKey


### PR DESCRIPTION
This patch adds support for the `-o|--options` flag to add freeform options to outgoing API requests.