### PR TITLE
Introduce Docker managed plugin for Ceph RBD

### DIFF
--- a/.docker/plugins/rbd/.Dockerfile
+++ b/.docker/plugins/rbd/.Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:7.3.1611
+
+LABEL drivers="${DRIVERS}"
+LABEL version="${VERSION}"
+
+ENV CEPH_VERSION kraken
+
+RUN rpm --import 'https://download.ceph.com/keys/release.asc'
+RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
+RUN yum install -y epel-release && yum clean all
+RUN yum install -y ceph-common e2fsprogs xfsprogs iproute && yum clean all
+
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+ADD rexray /usr/bin/rexray
+ADD rexray.yml /etc/rexray/rexray.yml
+
+ADD .rexray.sh /rexray.sh
+RUN chmod +x /rexray.sh
+
+CMD [ "rexray", "start", "-f", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/rbd/.rexray.sh
+++ b/.docker/plugins/rbd/.rexray.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# shellcheck shell=dash
+set -e
+
+# Workaround Docker bug that mount /sys as ro
+mount /sys -o remount,rw
+
+# first arg is `-f` or `--some-option`
+if [ "$(echo "$1" | \
+	awk  '{ string=substr($0, 1, 1); print string; }' )" = '-' ]; then
+	set -- rexray start -f --nopid "$@"
+fi
+
+#set default rexray options
+REXRAY_FSTYPE="${REXRAY_FSTYPE:-ext4}"
+REXRAY_LOGLEVEL="${REXRAY_LOGLEVEL:-warn}"
+REXRAY_PREEMPT="${REXRAY_PREEMPT:-false}"
+
+if [ "$1" = 'rexray' ]; then
+
+	for rexray_option in \
+		fsType \
+		loglevel \
+		preempt \
+	; do
+		val=$(eval echo "\$REXRAY_$(echo $rexray_option | \
+			awk '{print toupper($0)}')")
+		if [ "$val" ]; then
+			sed -ri 's/^([\ ]*'"$rexray_option"':).*/\1 '"$val"'/' \
+				/etc/rexray/rexray.yml
+		fi
+	done
+
+fi
+
+exec "$@"

--- a/.docker/plugins/rbd/README.md
+++ b/.docker/plugins/rbd/README.md
@@ -1,0 +1,1 @@
+# REX-Ray Docker Plug-in for Ceph RADOS Block Devices (RBD)

--- a/.docker/plugins/rbd/config.json
+++ b/.docker/plugins/rbd/config.json
@@ -1,0 +1,78 @@
+{
+      "Args": {
+        "Description": "",
+        "Name": "",
+        "Settable": null,
+        "Value": null
+      },
+      "Description": "REX-Ray for Ceph RBD",
+      "Documentation": "https://github.com/codedellemc/rexray/.docker/plugin/rbd",
+      "Entrypoint": [
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
+      ],
+      "Env": [
+        {
+          "Description": "",
+          "Name": "REXRAY_FSTYPE",
+          "Settable": [
+            "value"
+          ],
+          "Value": "ext4"
+        },
+        {
+          "Description": "",
+          "Name": "REXRAY_LOGLEVEL",
+          "Settable": [
+            "value"
+          ],
+          "Value": "warn"
+        },
+        {
+          "Description": "",
+          "Name": "RBD_DEFAULTPOOL",
+          "Settable": [
+            "value"
+          ],
+          "Value": "rbd"
+        },
+        {
+          "Description": "",
+          "Name": "RBD_TESTMODULE",
+          "Settable": [
+            "value"
+          ],
+          "Value": "false"
+        }
+      ],
+      "Interface": {
+        "Socket": "rexray.sock",
+        "Types": [
+          "docker.volumedriver/1.0"
+        ]
+      },
+      "Linux": {
+        "AllowAllDevices": true,
+        "Capabilities": ["CAP_SYS_ADMIN"],
+        "Devices": null
+      },
+      "Mounts": [
+        {
+          "Source": "/dev",
+          "Destination": "/dev",
+          "Type": "bind",
+          "Options": ["rbind"]
+        },
+        {
+          "Source": "/etc/ceph",
+          "Destination": "/etc/ceph",
+          "Type": "bind",
+          "Options": ["rbind"]
+        }
+      ],
+      "Network": {
+        "Type": "host"
+      },
+      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "User": {},
+      "WorkDir": ""
+}

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -149,6 +149,42 @@ Environment Variable | Description | Default | Required
 `S3FS_REGION` | The AWS region | |
 `S3FS_SECRETKEY` | The AWS secret key | | ✓
 
+## Ceph
+REX-Ray has a plug-in for Ceph RADOS Block Devices (RBD)
+
+### RBD
+The RBD plug-in can be installed with the following command:
+
+```bash
+$ docker plugin install rexray/rbd \
+  RBD_DEFAULTPOOL=rbd
+```
+
+### Requirements
+The RBD plug-in requires that the host has a fully working environment for
+mapping Ceph RBDs, including having the RBD kernel module already loaded. The
+cluster configuration and authentication files must be present in `/etc/ceph`.
+
+#### Privileges
+The RBD plug-in requires the following privileges:
+
+Type | Value
+-----|------
+network | `host`
+mount | `/dev`, `/etc/ceph`
+allow-all-devices | `true`
+capabilities | `CAP_SYS_ADMIN`
+
+#### Configuration
+The following environment variables can be used to configure the RBD
+plug-in:
+
+Environment Variable | Description | Default | Required
+---------------------|-------------|---------|---------
+`REXRAY_FSTYPE` | The type of file system to use | `ext4`
+`REXRAY_LOGLEVEL` | The log level | `warn`
+`RBD_DEFAULTPOOL` | Default Ceph pool for volumes | `rbd`
+
 ## Dell EMC
 REX-Ray includes plug-ins for several Dell EMC storage platforms.
 
@@ -434,4 +470,3 @@ Validate the volume was deleted successfully by listing the volumes:
 $ docker volume ls
 DRIVER              VOLUME NAME
 ```
-


### PR DESCRIPTION
Plugin image requires that we have the Ceph CLI/tools in the container,
so this plugin is built off of CentOS 7 instead of Alpine. As such, the
plugin has customized versions of rexray.sh and Dockerfile instead of
the common ones.

Closes #818.