### PR TITLE
Log libStorage error from logVolumeLoopError

### DIFF
--- a/cli/cli/cmds_10_volume.go
+++ b/cli/cli/cmds_10_volume.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/akutz/goof"
 	"github.com/spf13/cobra"
 
 	apitypes "github.com/codedellemc/libstorage/api/types"
@@ -577,6 +578,10 @@ func checkVolumeArgs(cmd *cobra.Command, args []string) {
 func (c *CLI) logVolumeLoopError(
 	processed interface{}, name, msg string, err error) {
 	logEntry := log.WithField("volume", name).WithError(err)
+	httpErr, ok := err.(goof.HTTPError)
+	if ok {
+		logEntry = logEntry.WithField("error.msg", httpErr.Error())
+	}
 	if c.continueOnError {
 		logEntry.Error(msg)
 	} else {


### PR DESCRIPTION
When libStorage would return an error like:
```json
{
  "message": "POST https://api.digitalocean.com/v2/volumes: 422 Storage is not supported for this region",
  "status": 500,
  "error": "POST https://api.digitalocean.com/v2/volumes: 422 Storage is not supported for this region"
}
```

The only thing printed to the REX-Ray CLI output was
"error.status=500", and not the actual error message. Fix that by
asserting type to goof.HTTPError, then extracting the real message.

Fixes codedellemc/libstorage#429

This ends up being the difference between a final output of:
```bash
FATA[0002] error creating volume                         error.status=500 volume=test
```
vs
```bash
FATA[0002] error creating volume                         error.status=500 error.msg=POST https://api.digitalocean.com/v2/volumes: 422 Storage is not supported for this region volume=test
```

I think the new output is much more helpful