### PR TITLE
Build Docker Plug-in Docs

### DIFF
--- a/.docs/dev-guide/build-reference.md
+++ b/.docs/dev-guide/build-reference.md
@@ -101,6 +101,30 @@ how REX-Ray is built:
 | --- | --- |
 | `DRIVERS` | This variable can be set to a space-delimited list of driver names in order to indicate which storage platforms to support. For example, the command `$ DRIVERS="ebs scaleio" make build` would build REX-Ray for only the EBS and ScaleIO storage platforms.
 
+## Build Docker Plug-ins
+This section describes how to build and create Docker plug-ins 
+and as such requires Docker. The `build.sh` command can be used 
+to build a Docker plug-in locally:
+
+```bash
+./build.sh -t plugin -d ebs
+```
+
+The `-t plugin` flag tells the command to build a Docker plug-in,
+and the `-d ebs` indicates the driver to include in the plug-in.
+
+!!! note "note"
+    If a plug-in definition does not already exist for the specified 
+    driver type then it will be created automatically. However, this
+    does not mean that a plug-in can be created for a driver that does
+    not already exist in libStorage. For example, `-d notreal` will 
+    fail because `notreal` is not a real driver.
+
+The above command will build the REX-Ray binary and include the specified
+driver, in this case `ebs`, and then create a Docker plug-in image with
+the new REX-Ray binary, similar to this 
+[gist](https://gist.github.com/akutz/2f62c5b55a8ba24171b1128fb822dc93#file-build-ebs-plugin-sh).
+
 ## Version File
 There is a file at the root of the project named `VERSION`. The file contains
 a single line with the *target* version of the project in the file. The version

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -47,6 +47,14 @@ Environment Variable | Description | Default Value
 `REXRAY_LOGLEVEL` | The log level | `warn`
 `REXRAY_PREEMPT` | Enable preemption | `false`
 
+### Building a Plug-in
+Please see the build reference for 
+[Docker plug-ins](../dev-guide/build-reference.md#build-docker-plug-ins).
+
+### Creating a Plug-in
+Please see the build reference for 
+[Docker plug-ins](../dev-guide/build-reference.md#build-docker-plug-ins).
+
 ## Amazon
 REX-Ray has plug-ins for multiple Amazon Web Services (AWS) storage services.
 

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,9 @@ usage() {
   ekho "                        This flag sets '-b make'."
   ekho
   ekho "       -t type          Optional. The type of REX-Ray binary to create."
-  ekho "                        Possible values include: agent, client, and controller"
+  ekho "                        Possible values include: agent, client, controller, and"
+  ekho "                        plugin."
+  ekho
   ekho "                        The default value is the same as omitting this flag and"
   ekho "                        argument altogether and will create a binary that"
   ekho "                        includes the agent, client, and controller."
@@ -405,8 +407,9 @@ create_dockerfile() {
   fi
 
   if [ "$GOOS" != "" ] || [ "$GOARCH" != "" ]; then
+    GOOS="${GOOS:-linux}"
+    GOARCH="${GOARCH:-amd64}"
     if [ "$GOOS" != "linux" ] || [ "$GOARCH" != "amd64" ]; then
-      GOOS="${GOOS:-linux}"
       GOOS_GOARCH_DIR="${GOOS}_${GOARCH}/"
     fi
   fi
@@ -763,6 +766,7 @@ if [ "$BTYPE" = "plugin" ]; then
   if [ "$DOCKER" != "1" ]; then
     ekho "error: the artifact used to create the plug-in can be built with "
     ekho "       make, but building the plug-in requires Docker"
+    exit 1
   fi
 
   FDRIVERS=$(echo "$DRIVERS" | tr ' ' '-' )


### PR DESCRIPTION
This patch updates the documentation to illustrate how to build Docker plug-ins locally using the `build.sh` command.

Fixes #797.