### PR TITLE
Go 1.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 language: go
 
 go:
-  - 1.8.1
+  - 1.8.3
 
 env:
   - REXRAY_BUILD_TYPE= TRAVIS_GOARCH=amd64

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ GOPATH := $(word 1,$(subst :, ,$(GOPATH)))
 
 ifneq (1,$(PORCELAIN))
 
-GO_VERSION := 1.8.1
+# define the go version to use
+GO_VERSION := $(TRAVIS_GO_VERSION)
+ifeq (,$(strip $(GO_VERSION)))
+GO_VERSION := $(shell grep -A 1 '^go:' .travis.yml | tail -n 1 | awk '{print $$2}')
+endif
 
 ifeq (undefined,$(origin BUILD_TAGS))
 BUILD_TAGS := gofig pflag libstorage_integration_driver_linux

--- a/build.sh
+++ b/build.sh
@@ -117,7 +117,9 @@ usage() {
 }
 
 # the version of go to use
-GO_VERSION="1.8.1"
+GO_VERSION="${TRAVIS_GO_VERSION:-$(grep -A 1 '^go:' .travis.yml | \
+  tail -n 1 | \
+  awk '{print $2}')}"
 
 # the makeflags to use for make commands
 MAKEFLAGS=--no-print-directory


### PR DESCRIPTION
This patch updates the REX-Ray build process to use Go 1.8.3.