### PR TITLE
Fakeroot Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,3 +122,4 @@ addons:
     - debhelper
     - dpkg
     - dpkg-dev
+    - fakeroot


### PR DESCRIPTION
This patch fixes #909, an issue created by Travis-CI updating their Trusty images -- the fakeroot package was no longer installed by default and it has been added to the list of packages to be installed in the .travis.yml file.