### PR TITLE
Add username param for rbd driver

### DIFF
--- a/libstorage/drivers/storage/rbd/executor/rbd_executor.go
+++ b/libstorage/drivers/storage/rbd/executor/rbd_executor.go
@@ -41,6 +41,10 @@ func (d *driver) Name() string {
 	return rbd.Name
 }
 
+func (d *driver) userName() string {
+	return d.config.GetString(rbd.ConfigUserName)
+}
+
 func (d *driver) Supported(
 	ctx types.Context,
 	opts types.Store) (bool, error) {
@@ -80,7 +84,9 @@ func (d *driver) LocalDevices(
 	ctx types.Context,
 	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
 
-	devMap, err := utils.GetMappedRBDs(ctx)
+	username := d.userName()
+
+	devMap, err := utils.GetMappedRBDs(ctx, username)
 	if err != nil {
 		return nil, err
 	}

--- a/libstorage/drivers/storage/rbd/rbd.go
+++ b/libstorage/drivers/storage/rbd/rbd.go
@@ -12,6 +12,9 @@ const (
 	// ConfigDefaultPool is the config key for default pool
 	ConfigDefaultPool = Name + ".defaultPool"
 
+	// ConfigUserName is the config key for rbd username
+	ConfigUserName = Name + ".userName"
+
 	// ConfigTestModule is the config key for testing kernel module presence
 	ConfigTestModule = Name + ".testModule"
 )
@@ -23,6 +26,7 @@ func init() {
 func registerConfig() {
 	r := gofigCore.NewRegistration("RBD")
 	r.Key(gofig.String, "", "rbd", "", ConfigDefaultPool)
+	r.Key(gofig.String, "", "admin", "", ConfigUserName)
 	r.Key(gofig.Bool, "", true, "", ConfigTestModule)
 	gofigCore.Register(r)
 }


### PR DESCRIPTION
Add userName parameter to the rbd driver to allow for isolating the
driver to an unpriviledged user with write access to a single rbd
pool.