### PR TITLE
Upload Build Info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.gist/
+md5sum.txt
+uname.txt
 files.txt
 /core/semver/semver
 semver.mk

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ jobs:
         - make bintray
       after_success:
         - make create-gist
+      after_failure:
+        - make create-gist
       deploy:
         - &deploy-to-bintray
           provider:       bintray
@@ -102,6 +104,8 @@ jobs:
         - ./$PROG version
         - make build-docker-plugin
       after_success:
+        - make create-gist
+      after_failure:
         - make create-gist
       deploy:
         - &deploy-docker


### PR DESCRIPTION
This patch updates CI builds so that upon success or failure a README is pushed to a gist that provides instructions on how to duplicate the build exactly using Docker. This process should produce a binary with the exact same checksum as the one built on the Travis-CI build server. For example:

![image](https://user-images.githubusercontent.com/101085/29006199-bec85d20-7ab0-11e7-882f-026439511473.png)
