### PR TITLE
New EBS config parameter for using larger device ranges

### DIFF
--- a/libstorage/.docs/user-guide/storage-providers.md
+++ b/libstorage/.docs/user-guide/storage-providers.md
@@ -81,7 +81,13 @@ all volumes that are created with a truthy encryption request field.
 - `statusTimeout` is a maximum length of time that polling for volume status can
   occur. This serves as a backstop against a stuck request of malfunctioning API
   that never returns.
-
+- `useLargeDeviceRange` specifies if REX-Ray should use largest available
+  device range `/dev/xvd[b-c][a-z]` for EBS volumes. By default this
+  parameter is `false`, so AWS recommended device range `/dev/xvd[f-p]` is used.
+  If this parameter is defined it must be defined both server and client-side.
+  See
+  [AWS documentation on device naming](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html)
+  for more information.
 
 For information on the equivalent environment variable and CLI flag names
 please see the section on how non top-level configuration properties are

--- a/libstorage/drivers/storage/ebs/ebs.go
+++ b/libstorage/drivers/storage/ebs/ebs.go
@@ -71,6 +71,14 @@ const (
 	// Encrypted flag set to true.
 	KmsKeyID = "kmsKeyID"
 
+	// ConfigUseLargeDeviceRange defines if Rex-RAY should use device mapping
+	// recommended by AWS (default), or a larger device ange that is
+	// supported but will not work on all instance types
+	ConfigUseLargeDeviceRange = Name + ".useLargeDeviceRange"
+
+	// defaultUseLargeDeviceRange is the default value for LargeDeviceSupport
+	defaultUseLargeDeviceRange = false
+
 	// ConfigStatusMaxAttempts is the key for the maximum number of times
 	// a volume status will be queried when waiting for an action to finish
 	ConfigStatusMaxAttempts = Name + ".statusMaxAttempts"
@@ -93,6 +101,8 @@ func init() {
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", Name+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", Name+"."+Tag)
 	r.Key(gofig.String, "", "", "", Name+"."+KmsKeyID)
+	r.Key(gofig.Bool, "", defaultUseLargeDeviceRange,
+		"Use Larger Device Range", ConfigUseLargeDeviceRange)
 	r.Key(gofig.Int, "", defaultStatusMaxAttempts, "Max Status Attempts",
 		ConfigStatusMaxAttempts)
 	r.Key(gofig.String, "", defaultStatusInitDelay, "Status Initial Delay",

--- a/libstorage/drivers/storage/ebs/utils/utils_unix.go
+++ b/libstorage/drivers/storage/ebs/utils/utils_unix.go
@@ -3,16 +3,58 @@
 package utils
 
 import (
+	"regexp"
+
 	"github.com/codedellemc/rexray/libstorage/api/types"
 )
 
-// NextDeviceInfo is the NextDeviceInfo object for EBS.
+// DeviceRange holds slices for device namespace iteration
+// and patterns for matching device nodes to specific namespaces.
 //
 // EBS suggests to use /dev/sd[f-p] for Linux EC2 instances. Also on Linux EC2
-// instances, although the device path may show up as /dev/sd* on the EC2 side,
-// it will appear locally as /dev/xvd*
-var NextDeviceInfo = &types.NextDeviceInfo{
-	Prefix:  "xvd",
-	Pattern: "[f-p]",
-	Ignore:  false,
+// instances, although the device path may show up as /dev/sd* on the EC2
+// side, it will appear locally as /dev/xvd*
+//
+// The broadest device path namespace available for Linux EC2 instances is
+// /dev/xvd[b-c][a-z]
+// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.htm
+type DeviceRange struct {
+	ParentLetters  []string
+	ChildLetters   []string
+	NextDeviceInfo *types.NextDeviceInfo
+	DeviceRE       *regexp.Regexp
+}
+
+var (
+	largeDeviceRange = &DeviceRange{
+		ParentLetters: []string{"b", "c"},
+		ChildLetters: []string{
+			"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+			"n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"},
+		NextDeviceInfo: &types.NextDeviceInfo{
+			Prefix:  "xvd",
+			Pattern: "[b-c][a-z]",
+			Ignore:  false,
+		},
+		DeviceRE: regexp.MustCompile(`^xvd[b-c][a-z]$`),
+	}
+	defaultDeviceRange = &DeviceRange{
+		ParentLetters: []string{"d"},
+		ChildLetters: []string{
+			"f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"},
+		NextDeviceInfo: &types.NextDeviceInfo{
+			Prefix:  "xvd",
+			Pattern: "[f-p]",
+			Ignore:  false,
+		},
+		DeviceRE: regexp.MustCompile(`^xvd[f-p]$`),
+	}
+)
+
+// GetDeviceRange returns a specified DeviceRange object
+func GetDeviceRange(useLargeDeviceRange bool) *DeviceRange {
+	if useLargeDeviceRange {
+		return largeDeviceRange
+	}
+	return defaultDeviceRange
 }


### PR DESCRIPTION
This proposed change has been previously discussed on these issues:

- Device attachment issues: #773 
- Proposed change to modify device range from `/dev/xvd[f-p]` to `/dev/xvd[b-c][a-z]`: https://github.com/codedellemc/libstorage/pull/598

I've now rebased the libstorage-specific change to the current REX-Ray `master`, since libstorage will be merged into this project. This change is targeted to the next REX-Ray version, which will be 0.10. Large device range has been introduced as a EBS configuration parameter `useLargeDeviceRange` which is `false` by default.

In order to workaround possible ghost device issues the device namespace is now iterated in a random order. This affects default behaviour as well.

In order to test this change both server and client-side re-configuration is required. Server configuration (in terms of EBS) should look like this:

```
ebs:
  accessKey:      foo
  secretKey:      bar
  region:         us-east-1
  maxRetries: 10
  statusTimeout: 240s
  statusInitialDelay: 50ms
  statusMaxAttempts: 10
  useLargeDeviceRange: true
```

Client configuration:

```
ebs:
  useLargeDeviceRange: true
```

Pre-built binary for amd64 architecture is available here: https://github.com/vtorhonen/rexray/releases/tag/v0.10.0-lds

Let me know if there's anything to fix/add.