### PR TITLE
Fix for LIBSTORAGE=false & Context service name

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -254,6 +254,12 @@ func InitializeModule(
 		return nil, goof.WithFields(lf, "unknown module type")
 	}
 
+	// inject the module's context with the service name
+	if v := modConfig.Config.GetString(apitypes.ConfigService); v != "" {
+		ctx = ctx.WithValue(apictx.ServiceKey, v)
+		ctx.WithField("serviceName", v).Info("set mod service name")
+	}
+
 	mod, initErr := mt.InitFunc(ctx, modConfig)
 	if initErr != nil {
 		return nil, initErr

--- a/agent/csi/libstorage/csi_service_libstorage.go
+++ b/agent/csi/libstorage/csi_service_libstorage.go
@@ -37,12 +37,13 @@ type driver struct {
 }
 
 func (d *driver) Serve(ctx context.Context, lis net.Listener) error {
+
 	d.ctx = apictx.New(ctx)
 	d.client = apictx.MustClient(d.ctx)
 
 	// Cache the name of the libStorage service for which this bridge
 	// is configured.
-	svcName, ok := apictx.ServiceName(ctx)
+	svcName, ok := apictx.ServiceName(d.ctx)
 	if !ok {
 		return errMissingServiceName
 	}

--- a/agent/csi/mod_csi.go
+++ b/agent/csi/mod_csi.go
@@ -113,7 +113,7 @@ func newModule(
 	}
 
 	// Create a gRPC server used to advertise the CSI service.
-	m.gs = newGrpcServer(m.ctx)
+	m.gs = newGrpcServer(ctx)
 	csi.RegisterControllerServer(m.gs, m.cs)
 	csi.RegisterIdentityServer(m.gs, m.cs)
 	csi.RegisterNodeServer(m.gs, m.cs)

--- a/agent/csi/mod_csi_service.go
+++ b/agent/csi/mod_csi_service.go
@@ -7,6 +7,7 @@ import (
 	xctx "golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	"github.com/codedellemc/gocsi"
 	"github.com/codedellemc/gocsi/csi"
 	"github.com/codedellemc/goioc"
 )
@@ -87,7 +88,10 @@ func (s *csiService) dial(
 		ctx,
 		s.serviceName,
 		grpc.WithInsecure(),
-		grpc.WithDialer(s.conn.DialGrpc))
+		grpc.WithDialer(s.conn.DialGrpc),
+		grpc.WithUnaryInterceptor(gocsi.ChainUnaryClient(
+			gocsi.ClientCheckReponseError,
+			gocsi.ClientResponseValidator)))
 }
 
 func (s *csiService) dialController(

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -190,11 +190,13 @@ func NewWithArgs(
 
 	noLibStorage := false
 	if strings.EqualFold("false", os.Getenv("LIBSTORAGE")) {
-		config.Set("libstorage", "false")
+		config.Set("libstorage.disabled", true)
 		noLibStorage = true
-	} else if config.GetString("libstorage") == "false" {
+		ctx.Info("libstorage disabled by env var")
+	} else if config.GetBool("libstorage.disabled") {
 		os.Setenv("LIBSTORAGE", "false")
 		noLibStorage = true
+		ctx.Info("libstorage disabled by config")
 	}
 	if noLibStorage {
 		config.Set("csi.driver", "csi-vfs")

--- a/libstorage/client/client.go
+++ b/libstorage/client/client.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	log "github.com/sirupsen/logrus"
 	gofig "github.com/akutz/gofig/types"
+	log "github.com/sirupsen/logrus"
 	gocontext "golang.org/x/net/context"
 
 	"github.com/codedellemc/rexray/libstorage/api/context"
@@ -75,9 +75,9 @@ func New(goCtx gocontext.Context, config gofig.Config) (types.Client, error) {
 	context.SetLogLevel(c.ctx, logConfig.Level)
 	c.ctx.WithFields(logFields).Info("configured logging")
 
-	if config.IsSet(types.ConfigService) {
-		c.ctx = c.ctx.WithValue(
-			context.ServiceKey, config.GetString(types.ConfigService))
+	if v := config.GetString(types.ConfigService); v != "" {
+		c.ctx = c.ctx.WithValue(context.ServiceKey, v)
+		c.ctx.WithField("serviceName", v).Info("set client service name")
 	}
 
 	storDriverName := config.GetString(types.ConfigStorageDriver)

--- a/util/util.go
+++ b/util/util.go
@@ -320,7 +320,7 @@ func ActivateLibStorage(
 	ctx apitypes.Context,
 	config gofig.Config) (apitypes.Context, gofig.Config, <-chan error, error) {
 
-	if !strings.EqualFold("false", config.GetString("libstorage")) {
+	if config.GetBool("libstorage.disabled") {
 		return ctx, config, nil, nil
 	}
 
@@ -380,7 +380,7 @@ var ErrMissingService = goof.New("client must specify service")
 func NewClient(
 	ctx apitypes.Context, config gofig.Config) (apitypes.Client, error) {
 
-	if !strings.EqualFold("false", config.GetString("libstorage")) {
+	if config.GetBool("libstorage.disabled") {
 		return nil, nil
 	}
 


### PR DESCRIPTION
This patch fixes the boolean logic for determining if libStorage is disabled as well as fixes how the service name is injected into the context.