### PR TITLE
Idempotent interceptor fixes

### DIFF
--- a/agent/csi/libstorage/csi_service_libstorage_idemp.go
+++ b/agent/csi/libstorage/csi_service_libstorage_idemp.go
@@ -171,9 +171,9 @@ func (d *driver) IsNodePublished(
 	}
 
 	if volMountPath == "" {
-		return false, fmt.Errorf(
-			"unable to find attached device for volume: id=%s, dev=%s",
-			idVal, devPath)
+		// Device hasn't been mounted anywhere yet, but we know
+		// it is already attached.
+		return false, nil
 	}
 
 	// Scan the mount table info and if an entry's device matches


### PR DESCRIPTION
This PR has two commits.

The first fixes an issue of the interceptor returning an error when the device is not found in the mount table -- this is not an error, it just means it hasn't been mounted (and the interceptor should allow the logic to continue to the CSI bridge.

The second commit adresses a couple of things. First is to account for the `/data` folder that occurs in libStorage mounted filesystems.

The second thing is to use the device token from the PublishVolumeInfo to use `LocalDevices` to get the underlying device when it is present. During an unpublish, this pointer is `nil`, and we have to fall back to a `VolumeInspect`.

As I am writing this, it dawned on me that the logic may still have issues with `BlockVolume` publishes, as right now it is blindly assuming it's a file system and appending `/data`. That's not going to work for `BlockVolume`... I see another change coming...

I tested in this on EBS, with doing attach, mount, unmount, detach repeatedly. Secondary calls were issued for all, and the idempotent interceptor picked them up correctly.

An area that needs to be tested is covering the bases for all types of storage/local-devices. Namely, EBS that returns a token of an actual device, ScaleIO that returns a token that get's transformed into a device, and EFS/S3FS that return no token at all.