### PR TITLE
Idempotent Errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -92,16 +92,16 @@
   revision = "32ae09ae44241977ba9f30bb2ae81bf8d8b2aa1c"
 
 [[projects]]
+  branch = "master"
   name = "github.com/codedellemc/csi-vfs"
   packages = ["provider","service"]
-  revision = "8c923a7ed211fc70323f455bb9975a42c5d1dab8"
-  version = "v0.1.4"
+  revision = "2c4efcbbceaa5e0c7acf95a041fbe90c0c06a914"
 
 [[projects]]
   branch = "master"
   name = "github.com/codedellemc/gocsi"
   packages = [".","csi","mount"]
-  revision = "39fd0eb9ee5cb7a104b8bc48d9c9afcea6657dd9"
+  revision = "2b8566b562bf21b9d375a46677fe9850ff44c356"
 
 [[projects]]
   name = "github.com/codedellemc/goioc"

--- a/agent/csi/libstorage/csi_service_libstorage_idemp.go
+++ b/agent/csi/libstorage/csi_service_libstorage_idemp.go
@@ -7,14 +7,17 @@ import (
 
 	"github.com/codedellemc/gocsi/csi"
 	"github.com/codedellemc/gocsi/mount"
+	xctx "golang.org/x/net/context"
 
 	apitypes "github.com/codedellemc/rexray/libstorage/api/types"
 	apiutils "github.com/codedellemc/rexray/libstorage/api/utils"
 )
 
-var errMissingIDKeyPath = errors.New("missing id key path")
-var errMissingTokenKey = errors.New("missing token key")
-var errUnableToGetLocDevs = errors.New("unable to get local devices")
+var (
+	errMissingIDKeyPath   = errors.New("missing id key path")
+	errMissingTokenKey    = errors.New("missing token key")
+	errUnableToGetLocDevs = errors.New("unable to get local devices")
+)
 
 const resNotFound = "resource not found"
 
@@ -25,7 +28,10 @@ func isNotFoundErr(err error) bool {
 // GetVolumeName should return the name of the volume specified
 // by the provided volume ID. If the volume does not exist then
 // an empty string should be returned.
-func (d *driver) GetVolumeName(id *csi.VolumeID) (string, error) {
+func (d *driver) GetVolumeName(
+	ctx xctx.Context,
+	id *csi.VolumeID) (string, error) {
+
 	idVal, ok := id.Values["id"]
 	if !ok {
 		return "", errMissingIDKeyPath
@@ -53,7 +59,10 @@ func (d *driver) GetVolumeName(id *csi.VolumeID) (string, error) {
 // GetVolumeInfo should return information about the volume
 // specified by the provided volume name. If the volume does not
 // exist then a nil value should be returned.
-func (d *driver) GetVolumeInfo(name string) (*csi.VolumeInfo, error) {
+func (d *driver) GetVolumeInfo(
+	ctx xctx.Context,
+	name string) (*csi.VolumeInfo, error) {
+
 	td, ok := d.client.Storage().(apitypes.StorageDriverVolInspectByName)
 	if !ok {
 		return nil, fmt.Errorf(
@@ -82,6 +91,7 @@ func (d *driver) GetVolumeInfo(name string) (*csi.VolumeInfo, error) {
 // IsControllerPublished should return publication info about
 // the volume specified by the provided volume name or ID.
 func (d *driver) IsControllerPublished(
+	ctx xctx.Context,
 	id *csi.VolumeID) (*csi.PublishVolumeInfo, error) {
 
 	idVal, ok := id.Values["id"]
@@ -121,6 +131,7 @@ func (d *driver) IsControllerPublished(
 // IsNodePublished should return a flag indicating whether or
 // not the volume exists and is published on the current host.
 func (d *driver) IsNodePublished(
+	ctx xctx.Context,
 	id *csi.VolumeID,
 	pubInfo *csi.PublishVolumeInfo,
 	targetPath string) (bool, error) {

--- a/vendor/github.com/codedellemc/csi-vfs/Gopkg.lock
+++ b/vendor/github.com/codedellemc/csi-vfs/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/codedellemc/gocsi"
   packages = [".","csi","mount"]
-  revision = "39fd0eb9ee5cb7a104b8bc48d9c9afcea6657dd9"
+  revision = "2b8566b562bf21b9d375a46677fe9850ff44c356"
 
 [[projects]]
   name = "github.com/codedellemc/goioc"

--- a/vendor/github.com/codedellemc/gocsi/.travis.yml
+++ b/vendor/github.com/codedellemc/gocsi/.travis.yml
@@ -71,7 +71,12 @@ jobs:
         script:
           - GOCSI_MOCK=$(pwd)/mock/mock make test
 
-      # Test the mount package.
+      # Test the mount package. This job requires a VM (sudo: required)
+      # because of the tests performing mount operations.
       - stage:   test
+        sudo:    required
         install: skip
-        script:  go test -v ./mount
+        script:
+          - go test -c -o mount.test ./mount
+          - mkdir -p /tmp/gocsi && cp mount.test /tmp/gocsi
+          - sudo /tmp/gocsi/mount.test -test.v

--- a/vendor/github.com/codedellemc/gocsi/trylock.go
+++ b/vendor/github.com/codedellemc/gocsi/trylock.go
@@ -15,8 +15,6 @@ type MutexWithTryLock interface {
 	TryLock(timeout time.Duration) bool
 }
 
-var tryLockNow = time.Duration(0)
-
 type mutex struct {
 	c chan int
 }


### PR DESCRIPTION
This patch updates the idempotent interceptor to allow for the cases where the guarded operation returns an error. If it does, that call for that volume will be marked as in error and a subsequent, same call for that volume will bypass the idempotent guard. Not until the handler returns a successful operation will the idempotent guard take effect once again for that volume for that particular operation.