### PR TITLE
Fixes mount error in Docker plug-in

### DIFF
--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update
 RUN apk add xfsprogs e2fsprogs ca-certificates
 
 RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml
 

--- a/.docker/plugins/cinder/config.json
+++ b/.docker/plugins/cinder/config.json
@@ -154,7 +154,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/dobs/config.json
+++ b/.docker/plugins/dobs/config.json
@@ -106,7 +106,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/ebs/config.json
+++ b/.docker/plugins/ebs/config.json
@@ -82,7 +82,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/efs/.Dockerfile
+++ b/.docker/plugins/efs/.Dockerfile
@@ -4,7 +4,7 @@ RUN apk update
 RUN apk add ca-certificates nfs-utils
 
 RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml
 

--- a/.docker/plugins/efs/config.json
+++ b/.docker/plugins/efs/config.json
@@ -98,7 +98,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/gcepd/config.json
+++ b/.docker/plugins/gcepd/config.json
@@ -82,7 +82,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/isilon/.Dockerfile
+++ b/.docker/plugins/isilon/.Dockerfile
@@ -4,7 +4,7 @@ RUN apk update
 RUN apk add ca-certificates nfs-utils
 
 RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml
 

--- a/.docker/plugins/isilon/config.json
+++ b/.docker/plugins/isilon/config.json
@@ -114,7 +114,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/rbd/.Dockerfile
+++ b/.docker/plugins/rbd/.Dockerfile
@@ -7,7 +7,7 @@ RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-releas
 RUN yum install -y epel-release && yum clean all
 RUN yum install -y ceph-common e2fsprogs xfsprogs iproute && yum clean all
 
-RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml
 

--- a/.docker/plugins/rbd/config.json
+++ b/.docker/plugins/rbd/config.json
@@ -72,7 +72,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/s3fs/.Dockerfile
+++ b/.docker/plugins/s3fs/.Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/s3fs-fuse/s3fs-fuse.git && cd s3fs-fuse && ./au
 RUN rm -rf /var/cache/apk/*
 
 RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml
 

--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -82,7 +82,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }

--- a/.docker/plugins/scaleio/.Dockerfile
+++ b/.docker/plugins/scaleio/.Dockerfile
@@ -12,7 +12,7 @@ RUN ln -s /lib/libuuid.so.1 /usr/glibc-compat/lib/
 RUN ln -s /usr/lib/libaio.so.1 /usr/glibc-compat/lib/
 RUN ln -s /usr/lib/libnuma.so.1 /usr/glibc-compat/lib/
 
-RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/libstorage/volumes
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml
 

--- a/.docker/plugins/scaleio/config.json
+++ b/.docker/plugins/scaleio/config.json
@@ -174,7 +174,7 @@
       "Network": {
         "Type": "host"
       },
-      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "PropagatedMount": "/var/lib/rexray/volumes",
       "User": {},
       "WorkDir": ""
 }


### PR DESCRIPTION
This patch fixes a mount error that occurs inside of a Docker plug-in due to the change in the private mount path used by REX-Ray.