### PR TITLE
Fixes panic when no val for -l|-c flags

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -558,7 +558,7 @@ func parseSafeHost(ctx apitypes.Context, h string) string {
 func FindFlagVal(name string, args ...string) (string, []int) {
 	var format string
 	if strings.HasPrefix(name, "--") {
-		format = `(?i)^%s(?:=(.+))?$`
+		format = `(?i)^%s(?:=(.*))?$`
 	} else {
 		format = `(?i)^%s$`
 	}
@@ -569,12 +569,16 @@ func FindFlagVal(name string, args ...string) (string, []int) {
 		case 0:
 			continue
 		case 1:
-			if i+1 <= len(args) {
+			if i+1 < len(args) {
 				return args[i+1], []int{i, i + 1}
 			}
+			return "", []int{i}
 		case 2:
 			if m[1] == "" {
-				return args[i+1], []int{i, i + 1}
+				if i+1 < len(args) {
+					return args[i+1], []int{i, i + 1}
+				}
+				return "", []int{i}
 			}
 			return m[1], []int{i}
 		}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -175,4 +175,37 @@ func TestFindFlagArgs(t *testing.T) {
 			t.Fatalf("invalid indices: %v", indices)
 		}
 	}
+
+	{
+		val, indices := util.FindFlagVal(
+			"-l", "rexray", "-l")
+		if val != "" {
+			t.Fatalf("val != '': %s", val)
+		}
+		if len(indices) != 1 && indices[0] != 1 {
+			t.Fatalf("invalid indices: %v", indices)
+		}
+	}
+
+	{
+		val, indices := util.FindFlagVal(
+			"--logLevel", "rexray", "--logLevel")
+		if val != "" {
+			t.Fatalf("val != '': %s", val)
+		}
+		if len(indices) != 1 && indices[0] != 1 {
+			t.Fatalf("invalid indices: %v", indices)
+		}
+	}
+
+	{
+		val, indices := util.FindFlagVal(
+			"--logLevel", "rexray", "--logLevel=")
+		if val != "" {
+			t.Fatalf("val != '': %s", val)
+		}
+		if len(indices) != 1 && indices[0] != 1 {
+			t.Fatalf("invalid indices: %v", indices)
+		}
+	}
 }


### PR DESCRIPTION
This patch fixes an issue where the early-code in REX-Ray's CLI execution would panic if the flags for setting the log level and custom configuration file, `-l|--logLevel` and `-c|--config`, did not have associated values and were the final argument on the command line.

Fixes #1019.