### PR TITLE
New Travis-CI Stage "Build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,46 @@ env:
 jobs:
   include:
 
-    # the first stage builds all of the tests, executes the framework
+    # the first stage builds all of the binaries possible, searching
+    # for any build errors that could possibly occur. this prevents
+    # the subsequent stages from wasting time enqueued for available vms
+    - &build-stage
+      stage:          build
+      language:       go
+      go:             1.8.3
+      go_import_path: github.com/codedellemc/rexray
+      env:            PROG=rexray
+      before_script:
+        - git fetch --unshallow --tags
+      script:
+        - make
+        - md5sum $PROG
+        - ls -al $PROG
+        - ./$PROG version
+
+    - <<: *build-stage
+      env: PROG=rexray-agent       TYPE=agent
+    - <<: *build-stage
+      env: PROG=rexray-controller  TYPE=controller
+
+    - <<: *build-stage
+      env: DRIVER=dobs
+    - <<: *build-stage
+      env: DRIVER=ebs
+    - <<: *build-stage
+      env: DRIVER=efs
+    - <<: *build-stage
+      env: DRIVER=gcepd
+    - <<: *build-stage
+      env: DRIVER=isilon
+    - <<: *build-stage
+      env: DRIVER=rbd
+    - <<: *build-stage
+      env: DRIVER=s3fs
+    - <<: *build-stage
+      env: DRIVER=scaleio
+
+    # the second stage builds all of the tests, executes the framework
     # tests using the vfs driver, and uploads the resulting coverage
     # results to codecov.io
     - stage:          test
@@ -22,7 +61,7 @@ jobs:
         - make test
         - make cover
 
-    # the second stage is responsible for producing the rexray stand-alone,
+    # the third stage is responsible for producing the rexray stand-alone,
     # agent, client, and controller binaries as well as packaging the
     # binaries and uploading them to bintray
     - &deploy-stage

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ PWD := $(shell pwd)
 
 # if GO_VERSION is not defined then parse it from the .travis.yml file
 ifeq (,$(strip $(GO_VERSION)))
-GO_VERSION := $(shell grep "go:" .travis.yml | awk '{print $$2}')
+GO_VERSION := $(shell grep "go:" .travis.yml | head -n 1 | awk '{print $$2}')
 endif
 
 # if GO_IMPORT_PATH is not defined then parse it from the .travis.yml file
 ifeq (,$(strip $(GO_IMPORT_PATH)))
-GO_IMPORT_PATH := $(shell grep "go_import_path:" .travis.yml | awk '{print $$2}')
+GO_IMPORT_PATH := $(shell grep "go_import_path:" .travis.yml | head -n 1 | awk '{print $$2}')
 endif
 # the import path less the github.com/ at the front
 GO_IMPORT_PATH_SLUG := $(subst github.com/,,$(GO_IMPORT_PATH))


### PR DESCRIPTION
This patch introduces a new stage to the Travis-CI configuration named "build". It is responsible for building all the variations of the REX-Ray binary, including a standard binary for each available driver.

Because the build phase uses containers instead of VMs, this new stage will ensure any build-time that might occur due to the different variations of build tags are caught before the overall build is put into a potentially long wait queue due to requiring VM resources for subsequent build stages.