### PR TITLE
Add GCE Convert Underscores Configuration.

### DIFF
--- a/.docker/plugins/gcepd/config.json
+++ b/.docker/plugins/gcepd/config.json
@@ -37,6 +37,14 @@
         },
         {
           "Description": "",
+          "Name": "GCEPD_CONVERTUNDERSCORES",
+          "Settable": [
+            "value"
+          ],
+          "Value": "false"
+        },
+        {
+          "Description": "",
           "Name": "GCEPD_DEFAULTDISKTYPE",
           "Settable": [
             "value"

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -348,6 +348,11 @@ $ docker plugin install rexray/gcepd \
 The GCEPD plug-in requires that GCE compute instance has Read/Write Cloud API
 access to the Compute Engine and Storage services.
 
+**NOTE:** GCE persistent disks cannot be created if their name contains an underscore.
+Docker will automatically append prefixes with underscores to your volume names when
+they are created as part of a compose file, so if you're creating volumes with this plugin
+using compose (or stack deploy), be sure to set `GCEPD_CONVERTUNDERSCORES` to `true`.
+
 #### Privileges
 The GCEPD plug-in requires the following privileges:
 
@@ -364,6 +369,7 @@ plug-in:
 
 Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
+`GCEPD_CONVERTUNDERSCORES` | Set to `true` if the plugin will reference persistent disks through a `docker-compose.yml` file | `false` |
 `GCEPD_DEFAULTDISKTYPE` | The default disk type to consume | `pd-ssd` |
 `GCEPD_TAG` | Only use volumes that are tagged with a label | |
 `GCEPD_ZONE` | GCE Availability Zone | |


### PR DESCRIPTION
Fixes https://github.com/codedellemc/rexray/issues/1020

@codenrhoden I just noticed https://github.com/codedellemc/rexray/pull/1030 as I created this PR, went ahead and added this one as well for the documentation updates as well.

Has the default value of `false` for converting underscores been discussed before for Digital Ocean and GCE?  It feels more reasonable to default to `true` given that it won't work otherwise... Or is the idea that we want it to break so that the user notices what is happening?
