### PR TITLE
Golang 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
     - &build-stage
       stage:          build
       language:       go
-      go:             1.8.3
+      go:             1.9
       go_import_path: github.com/codedellemc/rexray
       env:            PROG=rexray
       before_script:
@@ -52,7 +52,7 @@ jobs:
     # results to codecov.io
     - stage:          test
       language:       go
-      go:             1.8.3
+      go:             1.9
       go_import_path: github.com/codedellemc/rexray
       before_script:
         - git fetch --unshallow --tags


### PR DESCRIPTION
This patch updates the version of Go used to build REX-Ray to Go 1.9.