### PR TITLE
rbd: Add cephArgs config option

### DIFF
--- a/.docker/plugins/rbd/config.json
+++ b/.docker/plugins/rbd/config.json
@@ -53,6 +53,14 @@
         },
         {
           "Description": "",
+          "Name": "RBD_CEPHARGS",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "RBD_DEFAULTPOOL",
           "Settable": [
             "value"

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -205,6 +205,7 @@ plug-in:
 
 Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
+`RBD_CEPHARGS` | Text to set in the `CEPH_ARGS` environment variable | ""
 `RBD_DEFAULTPOOL` | Default Ceph pool for volumes | `rbd`
 
 ## Dell EMC

--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -407,9 +407,10 @@ cluster.
 * The `ceph` and `rbd` binary executables must be installed on the host
 * The minimum required version of Ceph *clients* is Infernalis, `v9.2.1`
 * The `rbd` kernel module must be installed
-* A `ceph.conf` file must be present in its default location
-  (`/etc/ceph/ceph.conf`)
-* The ceph `admin` key must be present in `/etc/ceph/`
+* A `<clustername>.conf` file must be present in its default location
+  (`/etc/ceph/`). By default, this is `/etc/ceph/ceph.conf`.
+* The specified user (`admin` by default) must have a keyring present in
+  `/etc/ceph/`.
 
 #### Configuration
 The following is an example with all possible fields configured. For a running
@@ -419,6 +420,7 @@ example see the [Examples](./storage-providers.md#ceph-rbd-examples) section.
 rbd:
   defaultPool: rbd
   testModule: true
+  cephArgs: --cluster testcluster
 ```
 
 ##### Configuration Notes
@@ -430,6 +432,11 @@ rbd:
   indicates whether the libStorage client should test if the `rbd` kernel module
   is loaded, with the side-effect of loading it if is not already loaded. This
   setting should be disabled when the driver is executing inside of a container.
+* The `cephArgs` parameter is optional, and defaults to an empty string. When
+  not empty, the value of `cepArgs` will be exported as the `CEPH_ARGS`
+  environment variable when making calls to the `rados` and `rbd` binaries. The
+  most common use of `cephArgs` is to set `--cluster` for an alternative cluster
+  name, or to set `--id` to use a different CephX user than `admin`.
 
 #### Runtime behavior
 
@@ -443,6 +450,11 @@ for the use of multiple pools by the driver. During a volume create, if the
 volume ID is given as `<pool>.<name>`, a volume named *name* will be created in
 the *pool* storage pool. If no pool is referenced, the `defaultPool` will be
 used.
+
+!!! note
+    When the `rbd.cephArgs` config option is set and contains any of the flags
+    `--id`, `--user`, `-n` or `--name`, support for multiple pools is
+    disabled and only the pool defined by `rbd.defaultPool` will be used.
 
 Both *pool* and *name* may only contain alphanumeric characters, underscores,
 and dashes.
@@ -461,7 +473,9 @@ driver name.
 #### Troubleshooting
 
 * Make sure that `ceph` and `rbd` commands work without extra parameters for
-  ID, key, and monitors. All configuration must come from `ceph.conf`.
+  monitors. All monitor addresses must come from `<clustername>.conf`. Be sure
+  to set/export `CEPH_ARGS` as appropriate based on whether `rbd.cephArgs` is
+  set.
 * Check status of the ceph cluster with `ceph -s` command.
 
 <a class="headerlink hiddenanchor" name="ceph-rbd-examples"></a>
@@ -481,13 +495,17 @@ libstorage:
         driver: rbd
         rbd:
           defaultPool: rbd
+          cephArgs: --id myuser
 ```
 
 #### Caveats
 * Snapshot and copy functionality is not yet implemented
 * libStorage Server must be running on each host to mount/attach RBD volumes
-* There is not yet options for using non-admin cephx keys or changing RBD create
-  features
+* There is not yet options for changing RBD create features
+* When using `rbd.cephArgs`, the specified user/ID must already be defined and
+  its keyring in place at `/etc/ceph/<clustername>.client.<id>.keyring`, and
+  any given cluster flag must have a config file at
+  `/etc/ceph/<clustername>.conf`.
 * Volume pre-emption is not supported. Ceph does not provide a method to
   forcefully detach a volume from a remote host -- only a host can attach and
   detach volumes from itself.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -313,6 +313,7 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 
 	if isHelpFlags(cmd) {
 		cmd.Help()
+		os.Exit(0)
 	}
 
 	if permErr := c.checkCmdPermRequirements(cmd); permErr != nil {
@@ -324,6 +325,7 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 
 		fmt.Println()
 		cmd.Help()
+		os.Exit(1)
 	}
 
 	c.ctx.WithField("val", os.Args).Debug("os.args")
@@ -354,6 +356,7 @@ func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 			}
 			fmt.Println()
 			cmd.Help()
+			os.Exit(1)
 		}
 	}
 }

--- a/libstorage/drivers/storage/rbd/executor/rbd_executor.go
+++ b/libstorage/drivers/storage/rbd/executor/rbd_executor.go
@@ -18,6 +18,12 @@ import (
 	"github.com/codedellemc/rexray/libstorage/drivers/storage/rbd/utils"
 )
 
+var (
+	// ctxConfigKey is an interface-wrapped key used to access a possible
+	// config object in the context
+	ctxConfigKey = interface{}("rbd.config")
+)
+
 type driver struct {
 	config     gofig.Config
 	doModprobe bool
@@ -97,6 +103,10 @@ func (d *driver) LocalDevices(
 func (d *driver) InstanceID(
 	ctx types.Context,
 	opts types.Store) (*types.InstanceID, error) {
+
+	// Inject the config into the context, so that the utils package can use
+	// to pick up any extra Ceph args
+	ctx = ctx.WithValue(ctxConfigKey, d.config)
 
 	return GetInstanceID(ctx, nil, nil)
 }

--- a/libstorage/drivers/storage/rbd/rbd.go
+++ b/libstorage/drivers/storage/rbd/rbd.go
@@ -14,6 +14,9 @@ const (
 
 	// ConfigTestModule is the config key for testing kernel module presence
 	ConfigTestModule = Name + ".testModule"
+
+	// ConfigCephArgs is the config key for the CEPH_ARGS env var
+	ConfigCephArgs = Name + ".cephArgs"
 )
 
 func init() {
@@ -24,5 +27,6 @@ func registerConfig() {
 	r := gofigCore.NewRegistration("RBD")
 	r.Key(gofig.String, "", "rbd", "", ConfigDefaultPool)
 	r.Key(gofig.Bool, "", true, "", ConfigTestModule)
+	r.Key(gofig.String, "", "", "", ConfigCephArgs)
 	gofigCore.Register(r)
 }


### PR DESCRIPTION
This patch adds an rbd.cephArgs config option. It takes free form text,
and is used to set the CEPH_ARGS env var. This env var is mostly used to
set "--id" and "--cluster" CLI args, the former being the name client
user to use (instead of admin) and the latter for using a non-default
cluster name (default is Ceph).

Using this field, a non-admin client and keyring can be used. Using that
client successfully means that the keyring has to be present in
/etc/ceph, and that the client's auth caps are set correctly. It is easy
to get in a situation where those are wrong, and calls to "rbd" or
"rados" hang instead of issuing "operation not permitted". To help
combat this, the driver no longer supports multiple pools when cephArgs
is set. Only the single pool defined as the defaultPool is supported.

I would have removed multi-pool support entirely, but that would break
backwards compatibility, and I've seen users use this functionality. But
setting CephArgs limits you to one pool only.

Replaces #934 
Fixes #924 
Fixes #955
xref #957 (addresses parts of it)

This patch also has an unrelated, 2nd commit with a fix I found necessary while working on the new feature.

Calling cmd.Help() prints the help output, but it does not exit the
program. There were places in the code were would detect a critical
error, emit it stderr, then emit the help output, but *not* exit the
program. This caused the program to continue execution leading to
potential faults from nil dereferences depending on what went wrong. We
really just want to emit the help then shutdown.