### PR TITLE
Enable S3FS_ENDPOINT for rexray/s3fs plugin

### DIFF
--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -21,6 +21,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": "/data"
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": "/data"
+        },
+        {
+          "Description": "",
+          "Name": "S3FS_ENDPOINT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "S3FS_ACCESSKEY",
           "Settable": [
             "value"


### PR DESCRIPTION
Additionally also enable envs to avoid using "/data"
as ROOTPATH, s3fs plugin doesn't have the same
restrictions as other storage drivers. It is necessary
to make top level prefixes and files to be visible.

Make this a default change such that the container
mounts see the entire bucket contents not just inside
"/data".