### PR TITLE
Add Docker managed plugin for Azure Unmanaged Disk

### DIFF
--- a/.docker/plugins/azureud/.Dockerfile
+++ b/.docker/plugins/azureud/.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.6
+
+RUN apk update
+RUN apk add xfsprogs e2fsprogs ca-certificates lsscsi
+
+RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
+ADD rexray /usr/bin/rexray
+ADD rexray.yml /etc/rexray/rexray.yml
+
+ADD rexray.sh /rexray.sh
+RUN chmod +x /rexray.sh
+
+CMD [ "rexray", "start", "-f", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/azureud/README.md
+++ b/.docker/plugins/azureud/README.md
@@ -1,0 +1,1 @@
+# REX-Ray Docker Plug-in for Azure Unmanaged Disks

--- a/.docker/plugins/azureud/config.json
+++ b/.docker/plugins/azureud/config.json
@@ -1,0 +1,168 @@
+{
+      "Args": {
+        "Description": "",
+        "Name": "",
+        "Settable": null,
+        "Value": null
+      },
+      "Description": "REX-Ray for Azure Unmanaged Disks",
+      "Documentation": "https://github.com/codedellemc/rexray/.docker/plugins/azureud",
+      "Entrypoint": [
+        "/rexray.sh", "rexray", "start", "-f", "--nopid"
+      ],
+      "Env": [
+        {
+          "Description": "",
+          "Name": "REXRAY_FSTYPE",
+          "Settable": [
+            "value"
+          ],
+          "Value": "ext4"
+        },
+        {
+          "Description": "",
+          "Name": "REXRAY_LOGLEVEL",
+          "Settable": [
+            "value"
+          ],
+          "Value": "warn"
+        },
+        {
+          "Description": "",
+          "Name": "REXRAY_PREEMPT",
+          "Settable": [
+            "value"
+          ],
+          "Value": "false"
+        },
+        {
+          "Description": "",
+          "Name": "LIBSTORAGE_SERVER_TASKS_EXETIMEOUT",
+          "Settable": [
+            "value"
+          ],
+          "Value": "120s"
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_CLIENTID",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_CLIENTSECRET",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_CONTAINER",
+          "Settable": [
+            "value"
+          ],
+          "Value": "vhds"
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_RESOURCEGROUP",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_STORAGEACCESSKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_STORAGEACCOUNT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_SUBSCRIPTIONID",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_TENANTID",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "AZUREUD_USEHTTPS",
+          "Settable": [
+            "value"
+          ],
+          "Value": "true"
+        },
+        {
+          "Description": "The sock file used by the CO to communicate with CSI.",
+          "Name": "CSI_ENDPOINT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "The name of the CSI plug-in used by the CSI module.",
+          "Name": "X_CSI_DRIVER",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "A flag that disables the CSI to libStorage bridge.",
+          "Name": "X_CSI_NATIVE",
+          "Settable": [
+            "value"
+          ],
+          "Value": "false"
+        }
+      ],
+      "Interface": {
+        "Socket": "rexray.sock",
+        "Types": [
+          "docker.volumedriver/1.0"
+        ]
+      },
+      "Linux": {
+        "AllowAllDevices": true,
+        "Capabilities": ["CAP_SYS_ADMIN"],
+        "Devices": null
+      },
+      "Mounts": [
+        {
+          "Source": "/dev",
+          "Destination": "/dev",
+          "Type": "bind",
+          "Options": ["rbind"]
+        }
+      ],
+      "Network": {
+        "Type": "host"
+      },
+      "PropagatedMount": "/var/lib/rexray/volumes",
+      "User": {},
+      "WorkDir": ""
+}

--- a/.docs/index.md
+++ b/.docs/index.md
@@ -136,7 +136,7 @@ The following storage providers and platforms are supported by REX-Ray.
 | DigitalOcean | [Block Storage](./user-guide/storage-providers.md#do-block-storage) | ✓ | ✓ | ✓ |
 | FittedCloud | [EBS Optimizer](./user-guide/storage-providers.md/#ebs-optimizer) | ✓ | ✓ | |
 | Google | [GCE Persistent Disk](./user-guide/storage-providers.md#gce-persistent-disk) | ✓ | ✓ | ✓ |
-| Microsoft | [Azure Unmanaged Disk](./user-guide/storage-providers.md#azure-ud) | ✓ | ✓ | |
+| Microsoft | [Azure Unmanaged Disk](./user-guide/storage-providers.md#azure-ud) | ✓ | ✓ | ✓ |
 | OpenStack | [Cinder](./user-guide/storage-providers.md#cinder) | ✓ | ✓ | ✓ |
 | VirtualBox | [Virtual Media](./user-guide/storage-providers.md#virtualbox) | ✓ | ✓ | |
 

--- a/.docs/user-guide/csi.md
+++ b/.docs/user-guide/csi.md
@@ -28,7 +28,7 @@ idempotent as well. Not only that, but REX-Ray supports native CSI plug-ins!
 | DigitalOcean | [Block Storage](./storage-providers.md#do-block-storage) | ✓ | ✓ | ✓ |
 | FittedCloud | [EBS Optimizer](./storage-providers.md/#ebs-optimizer) | ✓ | ✓ | |
 | Google | [GCE Persistent Disk](./storage-providers.md#gce-persistent-disk) | ✓ | ✓ | ✓ |
-| Microsoft | [Azure Unmanaged Disk](./storage-providers.md#azure-ud) | ✓ | ✓ | |
+| Microsoft | [Azure Unmanaged Disk](./storage-providers.md#azure-ud) | ✓ | ✓ | ✓ |
 | OpenStack | [Cinder](./storage-providers.md#cinder) | ✓ | ✓ | ✓ |
 | VirtualBox | [Virtual Media](./storage-providers.md#virtualbox) | ✓ | ✓ | |
 

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -374,6 +374,55 @@ Environment Variable | Description | Default | Required
 `GCEPD_TAG` | Only use volumes that are tagged with a label | |
 `GCEPD_ZONE` | GCE Availability Zone | |
 
+## Microsoft
+REX-Ray also includes a plug-in for Azure
+
+### Azure Unmanaged Disk
+The Azure Unmanaged Disk (Azure UD) plug-in can be installed with the following
+command:
+
+```bash
+$ docker plugin install rexray/azureud \
+  AZUREUD_CLIENTID=123def01-2345-6789-abcd-ef0123456789 \
+  AZUREUD_CLIENTSECRET=XXXXXXXX \
+  AZUREUD_RESOURCEGROUP=testgroup \
+  AZUREUD_STORAGEACCESSKEY=XXXXXXXX \
+  AZUREUD_STORAGEACCOUNT=username \
+  AZUREUD_SUBSCRIPTIONID=abcdef01-2345-6789-abcd-ef0123456789 \
+  AZUREUD_TENANTID=usernamehotmail.onmicrosoft.com
+```
+
+#### Requirements
+
+See [Azure UD](./storage-providers.md#azure-ud) driver documentation for detailed
+requirements
+
+#### Privileges
+The Azure UD plug-in requires the following privileges:
+
+Type | Value
+-----|------
+network | `host`
+mount | `/dev`
+allow-all-devices | `true`
+capabilities | `CAP_SYS_ADMIN`
+
+#### Configuration
+The following environment variables can be used to configure the Azure UD
+plug-in:
+
+Environment Variable | Description | Default | Required
+---------------------|-------------|---------|---------
+`AZUREUD_CLIENTID` | UUID of your client, which was created as an App Registration within your Azure active directory account |  | ✓
+`AZUREUD_CLIENTSECRET` | Valid access key associated with `AZUREUD_CLIENTID` | | ✓
+`AZUREUD_CONTAINER` | The name of an existing container within `storageAccount`. This container must already exist and is not created automatically. | `vhds` |
+`AZUREUD_RESOURCEGROUP` | Name of the resource group for your VMs and storage | | ✓
+`AZUREUD_STORAGEACCESSKEY` | Valid access key associated with `AZUREUD_STORAGEACCOUNT` | | ✓
+`AZUREUD_STORAGEACCOUNT` | Name of the storage account where your disks will be created | | ✓
+`AZUREUD_SUBSCRIPTIONID` | UUID of your Azure subscription | | ✓
+`AZUREUD_TENANTID` | Domain or UUID for your active directory account within Azure | | ✓
+`AZUREUD_USEHTTPS` | Boolean value on whether to use HTTPS when communicating with the Azure storage endpoin | `true` |
+
 ## OpenStack
 REX-Ray ships with plug-ins for OpenStack as well.
 

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -457,7 +457,7 @@ plug-in:
 
 Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
-`CINDER_AUTHURL` | The keystone authentication API |  | true
+`CINDER_AUTHURL` | The keystone authentication API |  | ✓
 `CINDER_USERID` | OpenStack userId for cinder access | |
 `CINDER_USERNAME` | OpenStack username for cinder access | |
 `CINDER_PASSWORD` | OpenStack user password for cinder access | |

--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -1240,7 +1240,7 @@ the driver name.
 
 #### Troubleshooting
 * For help creating App Registrations, the steps in
-  [this guide](https://www.terraform.io/docs/providers/azurerm/index.html#creating-credentials)
+  [this guide](https://www.terraform.io/docs/providers/azurerm/authenticating_via_service_principal.html#creating-a-service-principal)
   cover creating a new Registration using the Azure portal and CLI.
 * After creating your app registration, you must go into the
   `Required Permissions` tab and grant access to "Windows Azure Service

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ jobs:
     - &docker-stage
       stage:          docker
       language:       c
-      env:            DRIVER=cinder
+      env:            DRIVER=azureud
       services:       docker
       sudo:           required
       before_install:
@@ -167,6 +167,8 @@ jobs:
             all_branches: true
             condition: $DEPLOY_DOCKER != 0 && $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
+    - <<: *docker-stage
+      env: DRIVER=cinder
     - <<: *docker-stage
       env: DRIVER=dobs
     - <<: *docker-stage

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following storage providers and platforms are supported by REX-Ray.
 | DigitalOcean | [Block Storage](./user-guide/storage-providers.md#do-block-storage) | ✓ | ✓ | ✓ |
 | FittedCloud | [EBS Optimizer](./user-guide/storage-providers.md/#ebs-optimizer) | ✓ | ✓ | |
 | Google | [GCE Persistent Disk](./user-guide/storage-providers.md#gce-persistent-disk) | ✓ | ✓ | ✓ |
-| Microsoft | [Azure Unmanaged Disk](./user-guide/storage-providers.md#azure-ud) | ✓ | ✓ | |
+| Microsoft | [Azure Unmanaged Disk](./user-guide/storage-providers.md#azure-ud) | ✓ | ✓ | ✓ |
 | OpenStack | [Cinder](./user-guide/storage-providers.md#cinder) | ✓ | ✓ | ✓ |
 | VirtualBox | [Virtual Media](./user-guide/storage-providers.md#virtualbox) | ✓ | ✓ | |
 


### PR DESCRIPTION
Introduce the `azureud` Docker managed plugin. The Dockerfile for `azureud` needed to be custom so that it could add the `lsscsi` package, which is required for the driver.

The `config.json` file also sets the exe timeout for libStorage to 120 seconds by default, which is what we recommend in the driver documentation. The driver documentation has an updated link on how to create the Azure App Registration, as the hashicorp doc that we linked to before appears to have moved.

Fixes #817