### PR TITLE
Update RBD docker managed plugin to Luminous

### DIFF
--- a/.docker/plugins/rbd/.Dockerfile
+++ b/.docker/plugins/rbd/.Dockerfile
@@ -1,6 +1,6 @@
-FROM centos:7.3.1611
+FROM centos:7.4.1708
 
-ENV CEPH_VERSION kraken
+ENV CEPH_VERSION luminous
 
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm


### PR DESCRIPTION
This patch updates the Ceph packages in the RBD Docker managed plugin to
the Ceph Luminous release.

Fixes #1050