### PR TITLE
Docker plugin updates

### DIFF
--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -11,5 +11,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-CMD [ "rexray", "start", "-f", "--nopid" ]
+CMD [ "rexray", "start", "--nopid" ]
 ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk update
 RUN apk add xfsprogs e2fsprogs ca-certificates

--- a/.docker/plugins/azureud/.Dockerfile
+++ b/.docker/plugins/azureud/.Dockerfile
@@ -11,5 +11,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-CMD [ "rexray", "start", "-f", "--nopid" ]
+CMD [ "rexray", "start", "--nopid" ]
 ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/azureud/config.json
+++ b/.docker/plugins/azureud/config.json
@@ -45,6 +45,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "AZUREUD_CLIENTID",
           "Settable": [
             "value"

--- a/.docker/plugins/azureud/config.json
+++ b/.docker/plugins/azureud/config.json
@@ -45,6 +45,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "HTTP_PROXY",
           "Settable": [
             "value"

--- a/.docker/plugins/cinder/config.json
+++ b/.docker/plugins/cinder/config.json
@@ -45,6 +45,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "CINDER_AUTHURL",
           "Settable": [
             "value"

--- a/.docker/plugins/cinder/config.json
+++ b/.docker/plugins/cinder/config.json
@@ -37,6 +37,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "CINDER_AUTHURL",
           "Settable": [
             "value"

--- a/.docker/plugins/cinder/config.json
+++ b/.docker/plugins/cinder/config.json
@@ -164,6 +164,30 @@
           "Value": ""
         },
         {
+          "Description": "",
+          "Name": "CINDER_ATTACHTIMEOUT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "CINDER_CREATETIMEOUT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "CINDER_DELETETIMEOUT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
           "Description": "The sock file used by the CO to communicate with CSI.",
           "Name": "CSI_ENDPOINT",
           "Settable": [

--- a/.docker/plugins/dobs/config.json
+++ b/.docker/plugins/dobs/config.json
@@ -37,6 +37,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "DOBS_CONVERTUNDERSCORES",
           "Settable": [
             "value"

--- a/.docker/plugins/dobs/config.json
+++ b/.docker/plugins/dobs/config.json
@@ -45,6 +45,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "DOBS_CONVERTUNDERSCORES",
           "Settable": [
             "value"

--- a/.docker/plugins/ebs/config.json
+++ b/.docker/plugins/ebs/config.json
@@ -37,6 +37,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "EBS_ACCESSKEY",
           "Settable": [
             "value"

--- a/.docker/plugins/ebs/config.json
+++ b/.docker/plugins/ebs/config.json
@@ -77,6 +77,22 @@
         },
         {
           "Description": "",
+          "Name": "EBS_KMSKEYID",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_MAXRETRIES",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "EBS_REGION",
           "Settable": [
             "value"
@@ -86,6 +102,38 @@
         {
           "Description": "",
           "Name": "EBS_SECRETKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_STATUSINITIALDELAY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_STATUSMAXATTEMPTS",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_STATUSTIMEOUT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_USELARGEDEVICERANGE",
           "Settable": [
             "value"
           ],

--- a/.docker/plugins/ebs/config.json
+++ b/.docker/plugins/ebs/config.json
@@ -45,6 +45,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "EBS_ACCESSKEY",
           "Settable": [
             "value"

--- a/.docker/plugins/efs/.Dockerfile
+++ b/.docker/plugins/efs/.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk update
 RUN apk add ca-certificates nfs-utils

--- a/.docker/plugins/efs/.Dockerfile
+++ b/.docker/plugins/efs/.Dockerfile
@@ -11,5 +11,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-CMD [ "rexray", "start", "-f", "--nopid" ]
+CMD [ "rexray", "start", "--nopid" ]
 ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/efs/config.json
+++ b/.docker/plugins/efs/config.json
@@ -29,6 +29,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "EFS_ACCESSKEY",
           "Settable": [
             "value"

--- a/.docker/plugins/efs/config.json
+++ b/.docker/plugins/efs/config.json
@@ -37,6 +37,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "EFS_ACCESSKEY",
           "Settable": [
             "value"

--- a/.docker/plugins/efs/config.json
+++ b/.docker/plugins/efs/config.json
@@ -109,6 +109,30 @@
         },
         {
           "Description": "",
+          "Name": "EFS_STATUSINITIALDELAY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EFS_STATUSMAXATTEMPTS",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EFS_STATUSTIMEOUT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "CSI_ENDPOINT",
           "Settable": [
             "value"

--- a/.docker/plugins/gcepd/config.json
+++ b/.docker/plugins/gcepd/config.json
@@ -45,6 +45,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "GCEPD_CONVERTUNDERSCORES",
           "Settable": [
             "value"

--- a/.docker/plugins/gcepd/config.json
+++ b/.docker/plugins/gcepd/config.json
@@ -37,6 +37,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "GCEPD_CONVERTUNDERSCORES",
           "Settable": [
             "value"

--- a/.docker/plugins/gcepd/config.json
+++ b/.docker/plugins/gcepd/config.json
@@ -85,6 +85,30 @@
         },
         {
           "Description": "",
+          "Name": "GCEPD_STATUSINITIALDELAY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "GCEPD_STATUSMAXATTEMPTS",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "GCEPD_STATUSTIMEOUT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "GCEPD_TAG",
           "Settable": [
             "value"

--- a/.docker/plugins/isilon/.Dockerfile
+++ b/.docker/plugins/isilon/.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk update
 RUN apk add ca-certificates nfs-utils

--- a/.docker/plugins/isilon/.Dockerfile
+++ b/.docker/plugins/isilon/.Dockerfile
@@ -11,5 +11,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-CMD [ "rexray", "start", "-f", "--nopid" ]
+CMD [ "rexray", "start", "--nopid" ]
 ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/isilon/config.json
+++ b/.docker/plugins/isilon/config.json
@@ -69,6 +69,14 @@
         },
         {
           "Description": "",
+          "Name": "ISILON_GROUP",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "ISILON_INSECURE",
           "Settable": [
             "value"

--- a/.docker/plugins/isilon/config.json
+++ b/.docker/plugins/isilon/config.json
@@ -29,6 +29,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "ISILON_ENDPOINT",
           "Settable": [
             "value"

--- a/.docker/plugins/isilon/config.json
+++ b/.docker/plugins/isilon/config.json
@@ -37,6 +37,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "ISILON_ENDPOINT",
           "Settable": [
             "value"

--- a/.docker/plugins/rbd/.Dockerfile
+++ b/.docker/plugins/rbd/.Dockerfile
@@ -14,5 +14,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD .rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-CMD [ "rexray", "start", "-f", "--nopid" ]
+CMD [ "rexray", "start", "--nopid" ]
 ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/rbd/config.json
+++ b/.docker/plugins/rbd/config.json
@@ -29,6 +29,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "RBD_DEFAULTPOOL",
           "Settable": [
             "value"
@@ -55,12 +79,12 @@
           "Description": "A flag that disables the CSI to libStorage bridge.",
           "Name": "X_CSI_NATIVE",
           "Settable": [
-            "value" 
+            "value"
           ],
           "Value": "false"
         },
         {
-          "Description": "", 
+          "Description": "",
           "Name": "CSI_ENDPOINT",
           "Settable": [
             "value"

--- a/.docker/plugins/rexray.sh
+++ b/.docker/plugins/rexray.sh
@@ -2,10 +2,10 @@
 # shellcheck shell=dash
 set -e
 
-# first arg is `-f` or `--some-option`
+# first arg is `--some-option`
 if [ "$(echo "$1" | \
 	awk  '{ string=substr($0, 1, 1); print string; }' )" = '-' ]; then
-	set -- rexray start -f --nopid "$@"
+	set -- rexray start --nopid "$@"
 fi
 
 #set default rexray options

--- a/.docker/plugins/s3fs/.Dockerfile
+++ b/.docker/plugins/s3fs/.Dockerfile
@@ -16,5 +16,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-CMD [ "rexray", "start", "-f", "--nopid" ]
+CMD [ "rexray", "start", "--nopid" ]
 ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -77,6 +77,14 @@
         },
         {
           "Description": "",
+          "Name": "S3FS_MAXRETRIES",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "S3FS_OPTIONS",
           "Settable": [
             "value"

--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -25,7 +25,7 @@
           "Settable": [
             "value"
           ],
-          "Value": "/data"
+          "Value": ""
         },
         {
           "Description": "",
@@ -33,7 +33,15 @@
           "Settable": [
             "value"
           ],
-          "Value": "/data"
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
         },
         {
           "Description": "",

--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -37,6 +37,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "S3FS_ENDPOINT",
           "Settable": [
             "value"

--- a/.docker/plugins/scaleio/.Dockerfile
+++ b/.docker/plugins/scaleio/.Dockerfile
@@ -19,5 +19,5 @@ ADD rexray.yml /etc/rexray/rexray.yml
 ADD rexray.sh /rexray.sh
 RUN chmod +x /rexray.sh
 
-CMD [ "rexray", "start", "-f", "--nopid" ]
+CMD [ "rexray", "start", "--nopid" ]
 ENTRYPOINT [ "/rexray.sh" ]

--- a/.docker/plugins/scaleio/.Dockerfile
+++ b/.docker/plugins/scaleio/.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk update
 RUN apk add xfsprogs e2fsprogs ca-certificates libaio curl

--- a/.docker/plugins/scaleio/config.json
+++ b/.docker/plugins/scaleio/config.json
@@ -77,6 +77,14 @@
         },
         {
           "Description": "",
+          "Name": "SCALEIO_GUID",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "SCALEIO_INSECURE",
           "Settable": [
             "value"

--- a/.docker/plugins/scaleio/config.json
+++ b/.docker/plugins/scaleio/config.json
@@ -45,6 +45,30 @@
         },
         {
           "Description": "",
+          "Name": "LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_ROOTPATH",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "LINUX_VOLUME_FILEMODE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "SCALEIO_ENDPOINT",
           "Settable": [
             "value"

--- a/.docker/plugins/scaleio/config.json
+++ b/.docker/plugins/scaleio/config.json
@@ -37,6 +37,14 @@
         },
         {
           "Description": "",
+          "Name": "HTTP_PROXY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "SCALEIO_ENDPOINT",
           "Settable": [
             "value"

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -135,6 +135,9 @@ Environment Variable | Description | Default | Required
 `EFS_SECURITYGROUPS` | The AWS security groups to bind to | `default` |
 `EFS_TAG` | Only consume volumes with tag (tag\volume_name)| |
 `EFS_DISABLESESSIONCACHE` | new AWS connection is established with every API call | `false` |
+`EFS_STATUSINITIALDELAY` | Time duration used to wait when polling volume status | `1s` |
+`EFS_STATUSMAXATTEMPTS` | Number of times the status of a volume will be queried before giving up | `6` |
+`EFS_STATUSTIMEOUT` | Maximum length of time that polling for volume status can occur | `2m` |
 `HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ### Simple Storage Service

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -46,6 +46,9 @@ Environment Variable | Description | Default Value
 `REXRAY_FSTYPE` | The type of file system to use | `ext4`
 `REXRAY_LOGLEVEL` | The log level | `warn`
 `REXRAY_PREEMPT` | Enable preemption | `false`
+`LIBSTORAGE_INTEGRATION_VOLUME_OPERATIONS_MOUNT_ROOTPATH` | The path within the volume to return to the integrator | `/data`
+`LINUX_VOLUME_ROOTPATH` | A path to auto create within the volume | '/data'
+`LINUX_VOLUME_FILEMODE` | File mode for mounted path | `0700`
 
 ### Building a Plug-in
 Please see the build reference for

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -167,6 +167,7 @@ Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
 `S3FS_ACCESSKEY` | The AWS access key | | ✓
 `S3FS_DISABLEPATHSTYLE` | Disables use of path style for bucket endpoints | `false` |
+`S3FS_MAXRETRIES` | the number of retries that will be made for failed operations by the AWS SDK | 10 |
 `S3FS_OPTIONS` | Additional options to pass to S3FS | |
 `S3FS_REGION` | The AWS region | |
 `S3FS_SECRETKEY` | The AWS secret key | | ✓

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -87,8 +87,14 @@ plug-in:
 Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
 `EBS_ACCESSKEY` | The AWS access key | | ✓
-`EBS_SECRETKEY` | The AWS secret key | | ✓
+`EBS_KMSKEYID` | The encryption key for all volumes that are created with a truthy encryption request field | |
+`EBS_MAXRETRIES` | the number of retries that will be made for failed operations by the AWS SDK | 10 |
 `EBS_REGION` | The AWS region | `us-east-1` |
+`EBS_SECRETKEY` | The AWS secret key | | ✓
+`EBS_STATUSINITIALDELAY` | Time duration used to wait when polling volume status | `100ms` |
+`EBS_STATUSMAXATTEMPTS` | Number of times the status of a volume will be queried before giving up | `10` |
+`EBS_STATUSTIMEOUT` | Maximum length of time that polling for volume status can occur | `2m` |
+`EBS_USELARGEDEVICERANGE` | Use largest available device range `/dev/xvd[b-c][a-z]` for EBS volumes | false |
 `HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ### Elastic File System

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -204,8 +204,6 @@ plug-in:
 
 Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
-`REXRAY_FSTYPE` | The type of file system to use | `ext4`
-`REXRAY_LOGLEVEL` | The log level | `warn`
 `RBD_DEFAULTPOOL` | Default Ceph pool for volumes | `rbd`
 
 ## Dell EMC

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -480,6 +480,9 @@ Environment Variable | Description | Default | Required
 `CINDER_DOMAINNAME` | OpenStack domainName to authenticate | |
 `CINDER_REGIONNAME` | OpenStack regionName to authenticate | |
 `CINDER_AVAILABILITYZONENAME` | OpenStack availability zone for volumes | |
+`CINDER_ATTACHTIMEOUT` | Timeout for attaching volumes | `1m` |
+`CINDER_CREATETIMEOUT` | Timeout for creating volumes | `10m` |
+`CINDER_DELETETIMEOUT` | Timeout for creating volumes | `10m` |
 `HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -86,6 +86,7 @@ Environment Variable | Description | Default | Required
 `EBS_ACCESSKEY` | The AWS access key | | ✓
 `EBS_SECRETKEY` | The AWS secret key | | ✓
 `EBS_REGION` | The AWS region | `us-east-1` |
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ### Elastic File System
 The EFS plug-in can be installed with the following command:
@@ -125,6 +126,7 @@ Environment Variable | Description | Default | Required
 `EFS_SECURITYGROUPS` | The AWS security groups to bind to | `default` |
 `EFS_TAG` | Only consume volumes with tag (tag\volume_name)| |
 `EFS_DISABLESESSIONCACHE` | new AWS connection is established with every API call | `false` |
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ### Simple Storage Service
 The S3FS plug-in can be installed with the following command:
@@ -156,6 +158,7 @@ Environment Variable | Description | Default | Required
 `S3FS_OPTIONS` | Additional options to pass to S3FS | |
 `S3FS_REGION` | The AWS region | |
 `S3FS_SECRETKEY` | The AWS secret key | | ✓
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ## Ceph
 REX-Ray has a plug-in for Ceph RADOS Block Devices (RBD)
@@ -238,6 +241,7 @@ Environment Variable | Description | Default | Required
 `ISILON_NFSHOST` | The host or ip of your isilon nfs server | | ✓
 `ISILON_DATASUBNET` | The subnet for isilon nfs data traffic | | ✓
 `ISILON_QUOTAS` | Wanting to use quotas with isilon? | `false` |
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ### ScaleIO
 The ScaleIO plug-in can be installed with the following command:
@@ -288,6 +292,7 @@ Environment Variable | Description | Default | Required
 `SCALEIO_STORAGEPOOLNAME` | The name of the storage pool to use | | If `SCALEIO_STORAGEPOOLID` is omitted
 `SCALEIO_THINORTHICK` | The provision mode `(Thin|Thick)Provisioned` | |
 `SCALEIO_VERSION` | The version of ScaleIO system | |
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ## DigitalOcean
 REX-Ray ships with a plug-in for DigitalOcean to support their Block Storage service.
@@ -332,6 +337,7 @@ Environment Variable | Description | Default | Required
 `DOBS_STATUSMAXATTEMPTS` | Number of times the status of a volume will be queried before giving up | `10` |
 `DOBS_STATUSTIMEOUT` | Maximum length of time that polling for volume status can occur | `2m` |
 `DOBS_TOKEN` | Your DigitalOcean access token | | ✓
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ## Google
 REX-Ray ships with plug-ins for Google Compute Engine (GCE) as well.
@@ -373,6 +379,7 @@ Environment Variable | Description | Default | Required
 `GCEPD_DEFAULTDISKTYPE` | The default disk type to consume | `pd-ssd` |
 `GCEPD_TAG` | Only use volumes that are tagged with a label | |
 `GCEPD_ZONE` | GCE Availability Zone | |
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ## Microsoft
 REX-Ray also includes a plug-in for Azure
@@ -422,6 +429,7 @@ Environment Variable | Description | Default | Required
 `AZUREUD_SUBSCRIPTIONID` | UUID of your Azure subscription | | ✓
 `AZUREUD_TENANTID` | Domain or UUID for your active directory account within Azure | | ✓
 `AZUREUD_USEHTTPS` | Boolean value on whether to use HTTPS when communicating with the Azure storage endpoin | `true` |
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 ## OpenStack
 REX-Ray ships with plug-ins for OpenStack as well.
@@ -469,6 +477,7 @@ Environment Variable | Description | Default | Required
 `CINDER_DOMAINNAME` | OpenStack domainName to authenticate | |
 `CINDER_REGIONNAME` | OpenStack regionName to authenticate | |
 `CINDER_AVAILABILITYZONENAME` | OpenStack availability zone for volumes | |
+`HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |
 
 
 ## Examples

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -389,6 +389,9 @@ Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
 `GCEPD_CONVERTUNDERSCORES` | Set to `true` if the plugin will reference persistent disks through a `docker-compose.yml` file | `false` |
 `GCEPD_DEFAULTDISKTYPE` | The default disk type to consume | `pd-ssd` |
+`GCEPD_STATUSINITIALDELAY` | Time duration used to wait when polling volume status | `100ms` |
+`GCEPD_STATUSMAXATTEMPTS` | Number of times the status of a volume will be queried before giving up | `10` |
+`GCEPD_STATUSTIMEOUT` | Maximum length of time that polling for volume status can occur | `2m` |
 `GCEPD_TAG` | Only use volumes that are tagged with a label | |
 `GCEPD_ZONE` | GCE Availability Zone | |
 `HTTP_PROXY` | Address of HTTP proxy server to gain access to API endpoint | |

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -246,6 +246,7 @@ plug-in:
 Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
 `ISILON_ENDPOINT` | The Isilon web interface endpoint | | ✓
+`ISILON_GROUP` | The group to use when creating a volume | group of the user specified in the configuration |
 `ISILON_INSECURE` | Flag for insecure gateway connection | `false` |
 `ISILON_USERNAME` | Isilon user for connection | | ✓
 `ISILON_PASSWORD` | Isilon password | | ✓

--- a/.docs/user-guide/docker-plugins.md
+++ b/.docs/user-guide/docker-plugins.md
@@ -292,6 +292,7 @@ Environment Variable | Description | Default | Required
 ---------------------|-------------|---------|---------
 `REXRAY_FSTYPE` | The type of file system to use | `xfs` |
 `SCALEIO_ENDPOINT` | The ScaleIO gateway endpoint | | ✓
+`SCALEIO_GUID` | The ScaleIO client GUID | |
 `SCALEIO_INSECURE` | Flag for insecure gateway connection | `true` |
 `SCALEIO_USECERTS` | Flag indicating to require certificate validation | `false` |
 `SCALEIO_USERNAME` | ScaleIO user for connection | | ✓

--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -524,6 +524,9 @@ cinder:
   domainName:           corp
   regionName:           USNW
   availabilityZoneName: Gold
+  attachTimeout:        1m
+  createTimeout:        10m
+  deleteTimeout:        10m
 ```
 
 ##### Configuration Notes


### PR DESCRIPTION
This patchset has a series of commits that update the Docker plugins. They are in separate commits for easier review, and potential to revert if something is wrong.

All Alpine-based plugins are upgraded from 3.5->3.6, *except* for s3fs, which does not compile on 3.6 due to the replacement of openssl with libressl.

The start scripts for REX-Ray no longer use the deprecated `-f` flag.

All drivers that use and HTTP API now support the `HTTP_PROXY` env var. This ends up being every plugin except Ceph RBD.

New global options for volume rootpath and filemode are added, except for S3FS which should be taken care of by #1042.

Many plugins had their options more fully brought in line with what is available to the full drivers -- but not all options apply to the Docker managed plugins, so there are still discrepancies.

Fixes #933 
Fixes #1043