### PR TITLE
add missing drivers to Travis build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ jobs:
       env: PROG=rexray-controller  TYPE=controller
 
     - <<: *build-stage
+      env: DRIVER=azureud
+    - <<: *build-stage
+      env: DRIVER=cinder
+    - <<: *build-stage
       env: DRIVER=csi-nfs
     - <<: *build-stage
       env: DRIVER=dobs


### PR DESCRIPTION
I noticed when csi-nfs was added to travis-ci builds, it was added in two places, which reminded me that I forgot to add it in both places for `azureud`. Also noticed `cinder` was missing.