### PR TITLE
Add nfs-utils to Docker CSI-NFS plug-in

### DIFF
--- a/.docker/plugins/csi-nfs/.Dockerfile
+++ b/.docker/plugins/csi-nfs/.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.6
+
+RUN apk update
+RUN apk add xfsprogs e2fsprogs ca-certificates nfs-utils
+
+RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
+ADD rexray /usr/bin/rexray
+ADD rexray.yml /etc/rexray/rexray.yml
+
+ADD rexray.sh /rexray.sh
+RUN chmod +x /rexray.sh
+
+CMD [ "rexray", "start", "--nopid" ]
+ENTRYPOINT [ "/rexray.sh" ]


### PR DESCRIPTION
This patch adds the `nfs-utils` package to the Docker CSI-NFS plug-in. This patch addresses [this comment](https://github.com/codedellemc/rexray/issues/1066#issuecomment-336603385) from #1066.

Please note that while the original comment mentioned `nfs-tools`, that package does not appear to exist. Instead this patch uses `nfs-utils`. The latter was tested by running `docker run -it alpine:3.6 /bin/ash` and then running `apk update && apk add nfs-utils`. If there **is** some package named `nfs-tools` that needs to be installed, perhaps it was from an earlier version of Alpine or requires a custom package source?

cc @clintkitson @codenrhoden 