### PR TITLE
Docker Bridge Cache Warm Done Fix

### DIFF
--- a/agent/csi/mod_csi.go
+++ b/agent/csi/mod_csi.go
@@ -300,6 +300,7 @@ func (m *mod) Start() error {
 		// at listing the volumes using the bridge. This caches
 		// the volume name-to-ID mappings.
 		go func() {
+			defer m.waitForCancel.Done()
 			for {
 				if _, err := dbridge.List(); err == nil {
 					break
@@ -310,7 +311,6 @@ func (m *mod) Start() error {
 				case <-time.After(time.Duration(1) * time.Second):
 				}
 			}
-			m.waitForCancel.Done()
 		}()
 
 		dh := dvol.NewHandler(dbridge)


### PR DESCRIPTION
This patch updates the logic that warms the volume cache for the Docker Bridge so that the wait group's Done function is invoked in a defer statement to ensure it is not missed.

cc @codenrhoden 